### PR TITLE
fix: 番剧季度公开接口改走无凭证请求

### DIFF
--- a/crates/bili_sync/src/bilibili/bangumi.rs
+++ b/crates/bili_sync/src/bilibili/bangumi.rs
@@ -104,7 +104,7 @@ impl Bangumi {
         } else if let Some(ep_id) = &self.ep_id {
             // 通过 ep_id 获取 season_id
             let url = format!("https://api.bilibili.com/pgc/view/web/season?ep_id={}", ep_id);
-            let resp = self.client.get(&url, CancellationToken::new()).await?;
+            let resp = self.client.public_get(&url, CancellationToken::new()).await?;
             let json: serde_json::Value = resp.json().await?;
             json.validate()?["result"]["season_id"]
                 .as_str()
@@ -115,7 +115,7 @@ impl Bangumi {
         };
 
         let url = format!("https://api.bilibili.com/pgc/view/web/season?season_id={}", season_id);
-        let resp = self.client.get(&url, CancellationToken::new()).await?;
+        let resp = self.client.public_get(&url, CancellationToken::new()).await?;
         let json: serde_json::Value = resp.json().await?;
         json.validate().map(|v| v["result"].clone())
     }

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -257,6 +257,27 @@ impl BiliClient {
         Ok(response?)
     }
 
+    /// 发送不附带登录凭证的公开 GET 请求
+    pub async fn public_get(&self, url: &str, token: CancellationToken) -> Result<reqwest::Response> {
+        if let Some(limiter) = &self.limiter {
+            tokio::select! {
+                biased;
+                _ = token.cancelled() => return Err(anyhow!("Request cancelled in limiter")),
+                _ = limiter.acquire_one() => {},
+            }
+        }
+
+        let request_builder = self.client.request(Method::GET, url, None);
+
+        let response = tokio::select! {
+            biased;
+            _ = token.cancelled() => return Err(anyhow!("Request cancelled before send")),
+            res = request_builder.send() => res,
+        };
+
+        Ok(response?)
+    }
+
     pub async fn check_refresh(&self) -> Result<()> {
         let config = crate::config::reload_config();
         let credential = config.credential.load();

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -8299,7 +8299,7 @@ async fn get_season_title_from_api(
         match tokio::select! {
             biased;
             _ = token.cancelled() => return None,
-            res = bili_client.get(&url, token.clone()) => res,
+            res = bili_client.public_get(&url, token.clone()) => res,
         } {
             Ok(res) => {
                 if res.status().is_success() {
@@ -8394,7 +8394,7 @@ async fn get_bangumi_aid_from_api(bili_client: &BiliClient, ep_id: &str, token: 
         match tokio::select! {
             biased;
             _ = token.cancelled() => return None,
-            res = bili_client.get(&url, token.clone()) => res,
+            res = bili_client.public_get(&url, token.clone()) => res,
         } {
             Ok(res) => {
                 if res.status().is_success() {
@@ -8484,7 +8484,7 @@ async fn get_bangumi_info_from_api(
         match tokio::select! {
             biased;
             _ = token.cancelled() => return None,
-            res = bili_client.get(&url, token.clone()) => res,
+            res = bili_client.public_get(&url, token.clone()) => res,
         } {
             Ok(res) => {
                 if res.status().is_success() {
@@ -8616,7 +8616,7 @@ async fn get_season_info_from_api(
     let res = tokio::select! {
         biased;
         _ = token.cancelled() => return Err(anyhow!("Request cancelled")),
-        res = bili_client.get(&url, token.clone()) => res,
+        res = bili_client.public_get(&url, token.clone()) => res,
     }?;
 
     if !res.status().is_success() {


### PR DESCRIPTION
## Summary
- 将番剧季度相关的公开接口请求统一改为无凭证 GET，不再附带登录 Cookie 和 gaia_vtoken
- 覆盖季度标题、季度详情、EP 对应季度信息等 `pgc/view/web/season` 调用链路
- 保留现有重试与错误处理逻辑，只修正请求通道

## Why
- `https://api.bilibili.com/pgc/view/web/season` 本身是公开接口，无痕模式也可直接访问
- 之前代码走的是带凭证请求，容易把登录态、风控 token 或脏 Cookie 带进来，导致日志里出现误导性的季度获取失败

## Validation
- `cargo check`

## Notes
- 这次只改番剧季度公开接口的请求方式，不改番剧扫描和下载逻辑