### PR TITLE
支持弹幕增量更新与同步说明

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -40,9 +40,9 @@ use crate::api::response::{
     ConfigMigrationReportResponse, ConfigMigrationStatusResponse, ConfigReloadResponse, ConfigResponse,
     ConfigValidationResponse, DashBoardResponse, DeleteVideoResponse, DeleteVideoSourceResponse,
     HotReloadStatusResponse, InitialSetupCheckResponse, MonitoringStatus, PageInfo, QRGenerateResponse, QRPollResponse,
-    QRUserInfo, ResetAllVideosResponse, ResetVideoResponse, ResetVideoSourcePathResponse, SetupAuthTokenResponse,
-    SubmissionVideosResponse, UpdateConfigResponse, UpdateCredentialResponse, UpdateVideoStatusResponse, VideoInfo,
-    VideoResponse, VideoSource, VideoSourcesResponse, VideosResponse,
+    QRUserInfo, RefreshDanmakuResponse, ResetAllVideosResponse, ResetVideoResponse, ResetVideoSourcePathResponse,
+    SetupAuthTokenResponse, SubmissionVideosResponse, UpdateConfigResponse, UpdateCredentialResponse,
+    UpdateVideoStatusResponse, VideoInfo, VideoResponse, VideoSource, VideoSourcesResponse, VideosResponse,
 };
 use crate::api::wrapper::{ApiError, ApiResponse};
 use crate::utils::live_updates::{
@@ -797,8 +797,7 @@ mod reset_path_tests {
         let new_video_path = "/new-base/收藏夹/合集A";
         let old_page_path = "/downloads/收藏夹/合集A/Season 01/S01E001 - 测试页.m4s";
 
-        let remapped =
-            remap_page_path_with_video_prefix(old_page_path, old_video_path, new_video_path);
+        let remapped = remap_page_path_with_video_prefix(old_page_path, old_video_path, new_video_path);
 
         assert_eq!(
             remapped.as_deref(),
@@ -1033,6 +1032,10 @@ mod queue_sse_tests {
             play_audio_streams: Set(None),
             play_subtitle_streams: Set(None),
             play_streams_updated_at: Set(None),
+            danmaku_last_synced_at: Set(None),
+            danmaku_sync_generation: Set(0),
+            danmaku_cid_snapshot: Set(None),
+            danmaku_last_write_count: Set(0),
             ai_renamed: sea_orm::ActiveValue::NotSet,
         }
         .insert(db)
@@ -1329,7 +1332,7 @@ mod queue_sse_tests {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(get_video_sources, get_videos, get_video, reset_video, reset_all_videos, reset_specific_tasks, update_video_status, add_video_source, update_video_source_enabled, update_video_source_scan_deleted, update_video_source_scan_deleted_once, reset_video_source_path, delete_video_source, reload_config, get_config, update_config, get_bangumi_seasons, search_bilibili, get_user_favorites, get_user_collections, get_user_followings, get_subscribed_collections, get_submission_videos, get_logs, get_queue_status, cancel_queue_task, proxy_image, get_config_item, get_config_history, get_config_migration_status, migrate_config_schema, validate_config, get_hot_reload_status, check_initial_setup, setup_auth_token, update_credential, generate_qr_code, poll_qr_status, get_current_user, clear_credential, pause_scanning_endpoint, resume_scanning_endpoint, get_task_control_status, get_video_play_info, proxy_video_stream, validate_favorite, get_user_favorites_by_uid, test_notification_handler, get_notification_config, update_notification_config, get_notification_status, test_risk_control_handler, get_beta_image_update_status),
+    paths(get_video_sources, get_videos, get_video, refresh_video_danmaku, refresh_page_danmaku, reset_video, reset_all_videos, reset_specific_tasks, update_video_status, add_video_source, update_video_source_enabled, update_video_source_scan_deleted, update_video_source_scan_deleted_once, reset_video_source_path, delete_video_source, reload_config, get_config, update_config, get_bangumi_seasons, search_bilibili, get_user_favorites, get_user_collections, get_user_followings, get_subscribed_collections, get_submission_videos, get_logs, get_queue_status, cancel_queue_task, proxy_image, get_config_item, get_config_history, get_config_migration_status, migrate_config_schema, validate_config, get_hot_reload_status, check_initial_setup, setup_auth_token, update_credential, generate_qr_code, poll_qr_status, get_current_user, clear_credential, pause_scanning_endpoint, resume_scanning_endpoint, get_task_control_status, get_video_play_info, proxy_video_stream, validate_favorite, get_user_favorites_by_uid, test_notification_handler, get_notification_config, update_notification_config, get_notification_status, test_risk_control_handler, get_beta_image_update_status),
     modifiers(&OpenAPIAuth),
     security(
         ("Token" = []),
@@ -2432,8 +2435,22 @@ pub async fn get_video(
             page::Column::Name,
             page::Column::DownloadStatus,
             page::Column::Path,
+            page::Column::DanmakuLastSyncedAt,
+            page::Column::DanmakuSyncGeneration,
+            page::Column::DanmakuCidSnapshot,
+            page::Column::DanmakuLastWriteCount,
         ])
-        .into_tuple::<(i32, i32, String, u32, Option<String>)>()
+        .into_tuple::<(
+            i32,
+            i32,
+            String,
+            u32,
+            Option<String>,
+            Option<String>,
+            u32,
+            Option<i64>,
+            u32,
+        )>()
         .all(db.as_ref())
         .await?
         .into_iter()
@@ -2442,6 +2459,58 @@ pub async fn get_video(
     Ok(ApiResponse::ok(VideoResponse {
         video: video_info,
         pages,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/videos/{id}/refresh-danmaku",
+    params(
+        ("id" = i32, Path, description = "Video ID")
+    ),
+    responses(
+        (status = 200, body = ApiResponse<RefreshDanmakuResponse>),
+    )
+)]
+pub async fn refresh_video_danmaku(
+    Path(id): Path<i32>,
+    Extension(db): Extension<Arc<DatabaseConnection>>,
+) -> Result<ApiResponse<RefreshDanmakuResponse>, ApiError> {
+    let config = crate::config::reload_config();
+    let bili_client = crate::bilibili::BiliClient::new(String::new());
+    let refreshed_pages =
+        crate::workflow_danmaku::refresh_danmaku_for_video(id, &bili_client, db.as_ref(), &config).await?;
+
+    Ok(ApiResponse::ok(RefreshDanmakuResponse {
+        success: true,
+        refreshed_pages,
+        message: format!("已刷新 {} 个分页的弹幕", refreshed_pages),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/pages/{id}/refresh-danmaku",
+    params(
+        ("id" = i32, Path, description = "Page ID")
+    ),
+    responses(
+        (status = 200, body = ApiResponse<RefreshDanmakuResponse>),
+    )
+)]
+pub async fn refresh_page_danmaku(
+    Path(id): Path<i32>,
+    Extension(db): Extension<Arc<DatabaseConnection>>,
+) -> Result<ApiResponse<RefreshDanmakuResponse>, ApiError> {
+    let config = crate::config::reload_config();
+    let bili_client = crate::bilibili::BiliClient::new(String::new());
+    let refreshed_pages =
+        crate::workflow_danmaku::refresh_danmaku_for_page(id, &bili_client, db.as_ref(), &config).await?;
+
+    Ok(ApiResponse::ok(RefreshDanmakuResponse {
+        success: true,
+        refreshed_pages,
+        message: "已刷新当前分页的弹幕".to_string(),
     }))
 }
 
@@ -6129,7 +6198,8 @@ pub async fn update_video_source_download_options_internal(
     id: i32,
     params: crate::api::request::UpdateVideoSourceDownloadOptionsRequest,
 ) -> Result<crate::api::response::UpdateVideoSourceDownloadOptionsResponse, ApiError> {
-    let txn = crate::database::begin_traced_transaction(&db, "api.handler.update_video_source_download_options").await?;
+    let txn =
+        crate::database::begin_traced_transaction(&db, "api.handler.update_video_source_download_options").await?;
 
     let result = match source_type.as_str() {
         "collection" => {
@@ -7104,6 +7174,10 @@ async fn validate_path_reset_safety(
                 play_audio_streams: None,
                 play_subtitle_streams: None,
                 play_streams_updated_at: None,
+                danmaku_last_synced_at: None,
+                danmaku_sync_generation: 0,
+                danmaku_cid_snapshot: None,
+                danmaku_last_write_count: 0,
                 ai_renamed: None,
             };
 
@@ -7587,14 +7661,8 @@ fn remap_page_path_with_video_prefix(
 ) -> Option<String> {
     let candidate_prefixes = [
         (old_video_path.to_string(), new_video_path.to_string()),
-        (
-            old_video_path.replace('/', "\\"),
-            new_video_path.replace('/', "\\"),
-        ),
-        (
-            old_video_path.replace('\\', "/"),
-            new_video_path.replace('\\', "/"),
-        ),
+        (old_video_path.replace('/', "\\"), new_video_path.replace('/', "\\")),
+        (old_video_path.replace('\\', "/"), new_video_path.replace('\\', "/")),
     ];
 
     for (old_prefix, new_prefix) in candidate_prefixes {
@@ -7685,10 +7753,7 @@ async fn regenerate_video_and_page_paths_correctly(
 
         page::Entity::update_many()
             .filter(page::Column::Id.eq(page_model.id))
-            .col_expr(
-                page::Column::Path,
-                Expr::value(full_new_page_path),
-            )
+            .col_expr(page::Column::Path, Expr::value(full_new_page_path))
             .exec(txn)
             .await?;
     }
@@ -7795,6 +7860,13 @@ pub async fn get_config() -> Result<ApiResponse<crate::api::response::ConfigResp
         danmaku_bold: config.danmaku_option.bold,
         danmaku_outline: config.danmaku_option.outline,
         danmaku_time_offset: config.danmaku_option.time_offset,
+        danmaku_update_enabled: config.danmaku_update_policy.enabled,
+        danmaku_update_fresh_days: config.danmaku_update_policy.fresh_days,
+        danmaku_update_fresh_interval_hours: config.danmaku_update_policy.fresh_interval_hours,
+        danmaku_update_mature_days: config.danmaku_update_policy.mature_days,
+        danmaku_update_mature_interval_days: config.danmaku_update_policy.mature_interval_days,
+        danmaku_update_cold_days: config.danmaku_update_policy.cold_days,
+        danmaku_update_cold_interval_days: config.danmaku_update_policy.cold_interval_days,
         // 并发控制设置
         concurrent_video: config.concurrent_limit.video,
         concurrent_page: config.concurrent_limit.page,
@@ -7965,6 +8037,13 @@ pub async fn update_config(
             danmaku_bold: params.danmaku_bold,
             danmaku_outline: params.danmaku_outline,
             danmaku_time_offset: params.danmaku_time_offset,
+            danmaku_update_enabled: params.danmaku_update_enabled,
+            danmaku_update_fresh_days: params.danmaku_update_fresh_days,
+            danmaku_update_fresh_interval_hours: params.danmaku_update_fresh_interval_hours,
+            danmaku_update_mature_days: params.danmaku_update_mature_days,
+            danmaku_update_mature_interval_days: params.danmaku_update_mature_interval_days,
+            danmaku_update_cold_days: params.danmaku_update_cold_days,
+            danmaku_update_cold_interval_days: params.danmaku_update_cold_interval_days,
             // 并发控制设置
             concurrent_video: params.concurrent_video,
             concurrent_page: params.concurrent_page,
@@ -8068,6 +8147,13 @@ fn config_update_field_display_name(field: &str) -> String {
         "danmaku_bold" => Some("弹幕加粗"),
         "danmaku_outline" => Some("弹幕描边"),
         "danmaku_time_offset" => Some("弹幕时间偏移"),
+        "danmaku_update_enabled" => Some("弹幕增量更新开关"),
+        "danmaku_update_fresh_days" => Some("弹幕新鲜期天数"),
+        "danmaku_update_fresh_interval_hours" => Some("弹幕新鲜期刷新间隔"),
+        "danmaku_update_mature_days" => Some("弹幕成熟期天数"),
+        "danmaku_update_mature_interval_days" => Some("弹幕成熟期刷新间隔"),
+        "danmaku_update_cold_days" => Some("弹幕老化期天数"),
+        "danmaku_update_cold_interval_days" => Some("弹幕老化期刷新间隔"),
         "concurrent_video" => Some("同时处理视频数"),
         "concurrent_page" => Some("每视频并发分页数"),
         "rate_limit" => Some("请求频率限制"),
@@ -8559,6 +8645,68 @@ pub async fn update_config_internal(
             config.danmaku_option.time_offset = time_offset;
             updated_fields.push("danmaku_time_offset");
         }
+    }
+
+    if let Some(enabled) = params.danmaku_update_enabled {
+        if enabled != config.danmaku_update_policy.enabled {
+            config.danmaku_update_policy.enabled = enabled;
+            updated_fields.push("danmaku_update_enabled");
+        }
+    }
+
+    if let Some(days) = params.danmaku_update_fresh_days {
+        if days != config.danmaku_update_policy.fresh_days {
+            config.danmaku_update_policy.fresh_days = days;
+            updated_fields.push("danmaku_update_fresh_days");
+        }
+    }
+
+    if let Some(hours) = params.danmaku_update_fresh_interval_hours {
+        if hours == 0 {
+            return Err(anyhow!("弹幕新鲜期刷新间隔必须大于 0").into());
+        }
+        if hours != config.danmaku_update_policy.fresh_interval_hours {
+            config.danmaku_update_policy.fresh_interval_hours = hours;
+            updated_fields.push("danmaku_update_fresh_interval_hours");
+        }
+    }
+
+    if let Some(days) = params.danmaku_update_mature_days {
+        if days != config.danmaku_update_policy.mature_days {
+            config.danmaku_update_policy.mature_days = days;
+            updated_fields.push("danmaku_update_mature_days");
+        }
+    }
+
+    if let Some(days) = params.danmaku_update_mature_interval_days {
+        if days == 0 {
+            return Err(anyhow!("弹幕成熟期刷新间隔必须大于 0").into());
+        }
+        if days != config.danmaku_update_policy.mature_interval_days {
+            config.danmaku_update_policy.mature_interval_days = days;
+            updated_fields.push("danmaku_update_mature_interval_days");
+        }
+    }
+
+    if let Some(days) = params.danmaku_update_cold_days {
+        if days != config.danmaku_update_policy.cold_days {
+            config.danmaku_update_policy.cold_days = days;
+            updated_fields.push("danmaku_update_cold_days");
+        }
+    }
+
+    if let Some(days) = params.danmaku_update_cold_interval_days {
+        if days == 0 {
+            return Err(anyhow!("弹幕老化期刷新间隔必须大于 0").into());
+        }
+        if days != config.danmaku_update_policy.cold_interval_days {
+            config.danmaku_update_policy.cold_interval_days = days;
+            updated_fields.push("danmaku_update_cold_interval_days");
+        }
+    }
+
+    if let Err(err) = config.danmaku_update_policy.validate() {
+        return Err(anyhow!("弹幕增量更新策略无效：{}", err).into());
     }
 
     // 处理并发控制设置
@@ -9339,6 +9487,20 @@ pub async fn update_config_internal(
                 | "danmaku_time_offset" => {
                     manager
                         .update_config_item("danmaku_option", serde_json::to_value(&config.danmaku_option)?)
+                        .await
+                }
+                "danmaku_update_enabled"
+                | "danmaku_update_fresh_days"
+                | "danmaku_update_fresh_interval_hours"
+                | "danmaku_update_mature_days"
+                | "danmaku_update_mature_interval_days"
+                | "danmaku_update_cold_days"
+                | "danmaku_update_cold_interval_days" => {
+                    manager
+                        .update_config_item(
+                            "danmaku_update_policy",
+                            serde_json::to_value(&config.danmaku_update_policy)?,
+                        )
                         .await
                 }
                 // NFO配置字段
@@ -14569,6 +14731,10 @@ async fn update_bangumi_video_path_in_database(
             play_audio_streams: None,
             play_subtitle_streams: None,
             play_streams_updated_at: None,
+            danmaku_last_synced_at: None,
+            danmaku_sync_generation: 0,
+            danmaku_cid_snapshot: None,
+            danmaku_last_write_count: 0,
             ai_renamed: None,
         };
 
@@ -14710,6 +14876,10 @@ async fn move_bangumi_files_to_new_path(
             play_audio_streams: None,
             play_subtitle_streams: None,
             play_streams_updated_at: None,
+            danmaku_last_synced_at: None,
+            danmaku_sync_generation: 0,
+            danmaku_cid_snapshot: None,
+            danmaku_last_write_count: 0,
             ai_renamed: None,
         };
 

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -222,6 +222,13 @@ pub struct UpdateConfigRequest {
     pub danmaku_bold: Option<bool>,
     pub danmaku_outline: Option<f64>,
     pub danmaku_time_offset: Option<f64>,
+    pub danmaku_update_enabled: Option<bool>,
+    pub danmaku_update_fresh_days: Option<u32>,
+    pub danmaku_update_fresh_interval_hours: Option<u32>,
+    pub danmaku_update_mature_days: Option<u32>,
+    pub danmaku_update_mature_interval_days: Option<u32>,
+    pub danmaku_update_cold_days: Option<u32>,
+    pub danmaku_update_cold_interval_days: Option<u32>,
     // 并发控制设置
     pub concurrent_video: Option<usize>,
     pub concurrent_page: Option<usize>,

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -53,6 +53,13 @@ pub struct UpdateVideoStatusResponse {
 }
 
 #[derive(Serialize, ToSchema)]
+pub struct RefreshDanmakuResponse {
+    pub success: bool,
+    pub refreshed_pages: usize,
+    pub message: String,
+}
+
+#[derive(Serialize, ToSchema)]
 pub struct ResetAllVideosResponse {
     pub resetted: bool,
     pub resetted_videos_count: usize,
@@ -251,28 +258,70 @@ pub struct PageInfo {
     pub name: String,
     pub download_status: [u32; 5],
     pub path: Option<String>,
+    pub danmaku_last_synced_at: Option<String>,
+    pub danmaku_sync_generation: u32,
+    pub danmaku_cid_snapshot: Option<i64>,
+    pub danmaku_last_write_count: u32,
 }
 
 impl From<(i32, i32, String, u32)> for PageInfo {
     fn from((id, pid, name, download_status): (i32, i32, String, u32)) -> Self {
-        Self {
-            id,
-            pid,
-            name,
-            download_status: PageStatus::from(download_status).into(),
-            path: None,
-        }
+        Self::from((id, pid, name, download_status, None, None, 0, None, 0))
     }
 }
 
 impl From<(i32, i32, String, u32, Option<String>)> for PageInfo {
     fn from((id, pid, name, download_status, path): (i32, i32, String, u32, Option<String>)) -> Self {
+        Self::from((id, pid, name, download_status, path, None, 0, None, 0))
+    }
+}
+
+impl
+    From<(
+        i32,
+        i32,
+        String,
+        u32,
+        Option<String>,
+        Option<String>,
+        u32,
+        Option<i64>,
+        u32,
+    )> for PageInfo
+{
+    fn from(
+        (
+            id,
+            pid,
+            name,
+            download_status,
+            path,
+            danmaku_last_synced_at,
+            danmaku_sync_generation,
+            danmaku_cid_snapshot,
+            danmaku_last_write_count,
+        ): (
+            i32,
+            i32,
+            String,
+            u32,
+            Option<String>,
+            Option<String>,
+            u32,
+            Option<i64>,
+            u32,
+        ),
+    ) -> Self {
         Self {
             id,
             pid,
             name,
             download_status: PageStatus::from(download_status).into(),
             path,
+            danmaku_last_synced_at,
+            danmaku_sync_generation,
+            danmaku_cid_snapshot,
+            danmaku_last_write_count,
         }
     }
 }
@@ -422,6 +471,13 @@ pub struct ConfigResponse {
     pub danmaku_bold: bool,
     pub danmaku_outline: f64,
     pub danmaku_time_offset: f64,
+    pub danmaku_update_enabled: bool,
+    pub danmaku_update_fresh_days: u32,
+    pub danmaku_update_fresh_interval_hours: u32,
+    pub danmaku_update_mature_days: u32,
+    pub danmaku_update_mature_interval_days: u32,
+    pub danmaku_update_cold_days: u32,
+    pub danmaku_update_cold_interval_days: u32,
     // 并发控制设置
     pub concurrent_video: usize,
     pub concurrent_page: usize,

--- a/crates/bili_sync/src/bilibili/danmaku/ass_writer.rs
+++ b/crates/bili_sync/src/bilibili/danmaku/ass_writer.rs
@@ -8,6 +8,8 @@ use tokio::io::{AsyncWrite, AsyncWriteExt, BufWriter};
 use crate::bilibili::danmaku::canvas::CanvasConfig;
 use crate::bilibili::danmaku::{DanmakuOption, DrawEffect, Drawable};
 
+const EVENT_NAME_PREFIX: &str = "bsync-dm";
+
 struct TimePoint {
     t: f64,
 }
@@ -155,7 +157,7 @@ impl<W: AsyncWrite> AssWriter<W> {
             .write_all(
                 format!(
                     // Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-                    "Dialogue: 2,{start},{end},{style},,0,0,0,,{{{effect}\\c&H{b:02x}{g:02x}{r:02x}&}}{text}\n",
+                    "Dialogue: 2,{start},{end},{style},{name},0,0,0,,{{{effect}\\c&H{b:02x}{g:02x}{r:02x}&}}{text}\n",
                     start = TimePoint {
                         t: drawable.danmu.timeline_s
                     },
@@ -163,6 +165,7 @@ impl<W: AsyncWrite> AssWriter<W> {
                         t: drawable.danmu.timeline_s + drawable.duration
                     },
                     style = drawable.style_name,
+                    name = build_event_name(&drawable.danmu),
                     effect = AssEffect {
                         effect: drawable.effect
                     },
@@ -182,6 +185,26 @@ impl<W: AsyncWrite> AssWriter<W> {
     pub async fn flush(&mut self) -> Result<()> {
         Ok(self.f.flush().await?)
     }
+}
+
+fn build_event_name(danmu: &crate::bilibili::danmaku::Danmu) -> String {
+    match (danmu.source_id.as_deref(), danmu.sent_at) {
+        (Some(source_id), Some(sent_at)) if !source_id.is_empty() => {
+            format!("{EVENT_NAME_PREFIX}|{source_id}|{sent_at}")
+        }
+        _ => String::new(),
+    }
+}
+
+pub fn parse_event_name(value: &str) -> Option<(&str, i64)> {
+    let mut parts = value.trim().split('|');
+    let prefix = parts.next()?;
+    let source_id = parts.next()?;
+    let sent_at = parts.next()?.parse().ok()?;
+    if prefix != EVENT_NAME_PREFIX || source_id.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some((source_id, sent_at))
 }
 
 fn escape_text(text: &str) -> Cow<'_, str> {
@@ -231,5 +254,15 @@ mod tests {
             escape_text("呵\n呵\n比\n你\n们\n更\n喜\n欢\n晚\n晚").as_ref(),
             r"呵\N呵\N比\N你\N们\N更\N喜\N欢\N晚\N晚"
         );
+    }
+
+    #[test]
+    fn event_name_roundtrip() {
+        let name = build_event_name(&crate::bilibili::danmaku::Danmu {
+            source_id: Some("123456".to_string()),
+            sent_at: Some(1710000000),
+            ..Default::default()
+        });
+        assert_eq!(parse_event_name(&name), Some(("123456", 1710000000)));
     }
 }

--- a/crates/bili_sync/src/bilibili/danmaku/danmu.rs
+++ b/crates/bili_sync/src/bilibili/danmaku/danmu.rs
@@ -34,6 +34,8 @@ pub struct Danmu {
     /// 否在在调节分辨率的时候字体会发生变化。
     pub fontsize: u32,
     pub rgb: (u8, u8, u8),
+    pub sent_at: Option<i64>,
+    pub source_id: Option<String>,
 }
 
 impl Danmu {

--- a/crates/bili_sync/src/bilibili/danmaku/mod.rs
+++ b/crates/bili_sync/src/bilibili/danmaku/mod.rs
@@ -5,7 +5,7 @@ mod drawable;
 mod model;
 mod writer;
 
-pub use ass_writer::AssWriter;
+pub use ass_writer::{parse_event_name, AssWriter};
 pub use canvas::DanmakuOption;
 pub use danmu::Danmu;
 pub use drawable::{DrawEffect, Drawable};

--- a/crates/bili_sync/src/bilibili/danmaku/model.rs
+++ b/crates/bili_sync/src/bilibili/danmaku/model.rs
@@ -79,6 +79,12 @@ impl From<DanmakuElem> for Danmu {
                 ((elem.color >> 8) & 0xFF) as u8,
                 (elem.color & 0xFF) as u8,
             ),
+            sent_at: Some(elem.ctime),
+            source_id: if elem.dmid_str.is_empty() {
+                Some(elem.id.to_string())
+            } else {
+                Some(elem.dmid_str)
+            },
         }
     }
 }

--- a/crates/bili_sync/src/bilibili/danmaku/writer.rs
+++ b/crates/bili_sync/src/bilibili/danmaku/writer.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use tokio::fs::{self, File};
+use tokio::fs::{self, File, OpenOptions};
 
 use crate::bilibili::danmaku::canvas::{CanvasConfig, DanmakuOption};
 use crate::bilibili::danmaku::{AssWriter, Danmu};
@@ -21,16 +21,29 @@ impl<'a> DanmakuWriter<'a> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).await?;
         }
-        // 使用 with_config 来访问配置
-        let canvas_config = crate::config::with_config(|bundle| {
-            // 需要克隆 DanmakuOption 以避免生命周期问题
-            let danmaku_option = bundle.config.danmaku_option.clone();
-            // 使用 Box::leak 创建 'static 生命周期的引用
-            let static_option: &'static DanmakuOption = Box::leak(Box::new(danmaku_option));
-            CanvasConfig::new(static_option, self.page)
-        });
-        let mut writer =
-            AssWriter::construct(File::create(path).await?, self.page.name.clone(), canvas_config.clone()).await?;
+        let file = File::create(path).await?;
+        self.write_inner(file, true).await
+    }
+
+    pub async fn append(self, path: PathBuf) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let mut write_header = true;
+        if let Ok(metadata) = fs::metadata(&path).await {
+            write_header = metadata.len() == 0;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(path).await?;
+        self.write_inner(file, write_header).await
+    }
+
+    async fn write_inner(self, file: File, write_header: bool) -> Result<()> {
+        let canvas_config = canvas_config(self.page);
+        let mut writer = if write_header {
+            AssWriter::construct(file, self.page.name.clone(), canvas_config.clone()).await?
+        } else {
+            AssWriter::new(file, self.page.name.clone(), canvas_config.clone())
+        };
         let mut canvas = canvas_config.canvas();
         for danmuku in self.danmaku {
             if let Some(drawable) = canvas.draw(danmuku)? {
@@ -40,4 +53,12 @@ impl<'a> DanmakuWriter<'a> {
         writer.flush().await?;
         Ok(())
     }
+}
+
+fn canvas_config(page: &PageInfo) -> CanvasConfig {
+    crate::config::with_config(|bundle| {
+        let danmaku_option = bundle.config.danmaku_option.clone();
+        let static_option: &'static DanmakuOption = Box::leak(Box::new(danmaku_option));
+        CanvasConfig::new(static_option, page)
+    })
 }

--- a/crates/bili_sync/src/bilibili/mod.rs
+++ b/crates/bili_sync/src/bilibili/mod.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Utc};
 pub use client::{BiliClient, Client, SearchResult};
 pub use collection::{Collection, CollectionEpisodeOrderStrategy, CollectionItem, CollectionType};
 pub use credential::Credential;
-pub use danmaku::DanmakuOption;
+pub use danmaku::{parse_event_name, DanmakuElem, DanmakuOption, DanmakuWriter};
 pub use dynamic::Dynamic;
 pub use error::BiliError;
 pub use favorite_list::FavoriteList;

--- a/crates/bili_sync/src/bilibili/video.rs
+++ b/crates/bili_sync/src/bilibili/video.rs
@@ -419,7 +419,7 @@ impl<'a> Video<'a> {
         Ok(serde_json::from_value(res["data"].take())?)
     }
 
-    pub async fn get_danmaku_writer(&self, page: &'a PageInfo, token: CancellationToken) -> Result<DanmakuWriter<'a>> {
+    pub async fn get_danmaku_elements(&self, page: &'a PageInfo, token: CancellationToken) -> Result<Vec<DanmakuElem>> {
         let segment_count = page.duration.div_ceil(360);
         debug!("开始获取弹幕，共{}个分段", segment_count);
 
@@ -449,6 +449,11 @@ impl<'a> Video<'a> {
         all_danmaku.sort_by_key(|d| d.progress);
         debug!("弹幕获取完成，共{}条弹幕", all_danmaku.len());
 
+        Ok(all_danmaku)
+    }
+
+    pub async fn get_danmaku_writer(&self, page: &'a PageInfo, token: CancellationToken) -> Result<DanmakuWriter<'a>> {
+        let all_danmaku = self.get_danmaku_elements(page, token).await?;
         Ok(DanmakuWriter::new(
             page,
             all_danmaku.into_iter().map(|x| x.into()).collect(),

--- a/crates/bili_sync/src/config/item.rs
+++ b/crates/bili_sync/src/config/item.rs
@@ -281,6 +281,62 @@ impl Default for SubmissionScanStrategyConfig {
     }
 }
 
+/// 弹幕增量更新策略。
+///
+/// 采用三段式调度：
+/// - 新鲜期：发布时间后的 `fresh_days` 天内，每 `fresh_interval_hours` 小时刷新一次
+/// - 成熟期：之后到 `mature_days` 天内，每 `mature_interval_days` 天刷新一次
+/// - 老化期：之后到 `cold_days` 天内，每 `cold_interval_days` 天刷新一次
+/// - 冷冻期：超过 `cold_days` 后自动冻结，不再后台轮询
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DanmakuUpdatePolicy {
+    pub enabled: bool,
+    pub fresh_days: u32,
+    pub fresh_interval_hours: u32,
+    pub mature_days: u32,
+    pub mature_interval_days: u32,
+    pub cold_days: u32,
+    pub cold_interval_days: u32,
+}
+
+impl Default for DanmakuUpdatePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            fresh_days: 3,
+            fresh_interval_hours: 6,
+            mature_days: 30,
+            mature_interval_days: 3,
+            cold_days: 180,
+            cold_interval_days: 30,
+        }
+    }
+}
+
+impl DanmakuUpdatePolicy {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !self.enabled {
+            return Ok(());
+        }
+        if self.fresh_days > self.mature_days {
+            return Err("fresh_days 不能大于 mature_days");
+        }
+        if self.mature_days > self.cold_days {
+            return Err("mature_days 不能大于 cold_days");
+        }
+        if self.fresh_interval_hours == 0 {
+            return Err("fresh_interval_hours 必须大于 0");
+        }
+        if self.mature_interval_days == 0 {
+            return Err("mature_interval_days 必须大于 0");
+        }
+        if self.cold_interval_days == 0 {
+            return Err("cold_interval_days 必须大于 0");
+        }
+        Ok(())
+    }
+}
+
 fn default_large_submission_threshold() -> usize {
     80
 }

--- a/crates/bili_sync/src/config/manager.rs
+++ b/crates/bili_sync/src/config/manager.rs
@@ -54,6 +54,7 @@ pub(crate) fn describe_config_key(key: &str) -> &'static str {
         "credential" => "B站登录凭证",
         "filter_option" => "画质与编码过滤",
         "danmaku_option" => "弹幕下载/样式设置",
+        "danmaku_update_policy" => "弹幕增量更新策略",
         "video_name" => "视频命名模板",
         "page_name" => "分页命名模板",
         "multi_page_name" => "多P分页命名模板",

--- a/crates/bili_sync/src/config/mod.rs
+++ b/crates/bili_sync/src/config/mod.rs
@@ -20,8 +20,8 @@ pub use crate::config::global::{
 };
 use crate::config::item::ConcurrentLimit;
 pub use crate::config::item::{
-    EmptyUpperStrategy, NFOConfig, NFOTimeType, PathSafeTemplate, RateLimit, SubmissionRiskControlConfig,
-    SubmissionScanStrategyConfig,
+    DanmakuUpdatePolicy, EmptyUpperStrategy, NFOConfig, NFOTimeType, PathSafeTemplate, RateLimit,
+    SubmissionRiskControlConfig, SubmissionScanStrategyConfig,
 };
 pub(crate) use crate::config::manager::describe_config_key;
 pub use crate::config::manager::ConfigManager;
@@ -166,6 +166,8 @@ pub struct Config {
     pub filter_option: FilterOption,
     #[serde(default)]
     pub danmaku_option: DanmakuOption,
+    #[serde(default)]
+    pub danmaku_update_policy: DanmakuUpdatePolicy,
     #[serde(default = "default_video_name")]
     pub video_name: Cow<'static, str>,
     #[serde(default = "default_page_name")]
@@ -664,6 +666,7 @@ impl Clone for Config {
                 outline: self.danmaku_option.outline,
                 time_offset: self.danmaku_option.time_offset,
             },
+            danmaku_update_policy: self.danmaku_update_policy.clone(),
             video_name: self.video_name.clone(),
             page_name: self.page_name.clone(),
             multi_page_name: self.multi_page_name.clone(),
@@ -712,6 +715,7 @@ impl Default for Config {
             credential: ArcSwapOption::from(Some(Arc::new(Credential::default()))),
             filter_option: FilterOption::default(),
             danmaku_option: DanmakuOption::default(),
+            danmaku_update_policy: DanmakuUpdatePolicy::default(),
             video_name: Cow::Borrowed("{{upper_name}}/{{title}}"),
             page_name: Cow::Borrowed("{{pubtime}}-{{bvid}}-{{truncate title 20}}"),
             multi_page_name: Cow::Borrowed("P{{pid_pad}}.{{ptitle}}"),
@@ -834,6 +838,11 @@ impl Config {
         if !(self.concurrent_limit.video > 0 && self.concurrent_limit.page > 0) {
             ok = false;
             error!("video 和 page 允许的并发数必须大于 0");
+        }
+
+        if let Err(err) = self.danmaku_update_policy.validate() {
+            ok = false;
+            error!("弹幕增量更新策略无效：{}", err);
         }
 
         if critical_error {

--- a/crates/bili_sync/src/database.rs
+++ b/crates/bili_sync/src/database.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use bili_sync_migration::{Migrator, MigratorTrait};
 use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sea_orm::sqlx::{self, Executor};
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, DbErr, ExecResult, QueryResult, SqlxSqliteConnector, Statement, StreamTrait};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DbBackend, DbErr, ExecResult, QueryResult, SqlxSqliteConnector, Statement,
+    StreamTrait,
+};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
@@ -59,9 +62,7 @@ fn is_database_locked_message(message: &str) -> bool {
 
 fn active_db_operation_snapshots(exclude_id: Option<u64>) -> Vec<ActiveDbOperationSnapshot> {
     let now = Instant::now();
-    let operations = ACTIVE_DB_OPERATIONS
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
+    let operations = ACTIVE_DB_OPERATIONS.lock().unwrap_or_else(|e| e.into_inner());
     let mut snapshot = operations
         .iter()
         .filter(|(id, _)| Some(**id) != exclude_id)
@@ -105,7 +106,12 @@ fn classify_active_db_operation_contention(
     }
 }
 
-fn log_active_db_operation_contention(message_prefix: &str, idle_message: &str, current: &str, exclude_id: Option<u64>) {
+fn log_active_db_operation_contention(
+    message_prefix: &str,
+    idle_message: &str,
+    current: &str,
+    exclude_id: Option<u64>,
+) {
     let occupied = active_db_operation_snapshots(exclude_id);
     let Some(level) = classify_active_db_operation_contention(&occupied) else {
         debug!("{}: {}", idle_message, current);
@@ -157,16 +163,13 @@ impl DbOperationGuard {
     fn begin_inner(name: String, started_at: Instant, emit_start_log: bool) -> Self {
         let id = NEXT_DB_OPERATION_ID.fetch_add(1, Ordering::Relaxed);
 
-        ACTIVE_DB_OPERATIONS
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(
-                id,
-                ActiveDbOperation {
-                    name: name.clone(),
-                    started_at,
-                },
-            );
+        ACTIVE_DB_OPERATIONS.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            id,
+            ActiveDbOperation {
+                name: name.clone(),
+                started_at,
+            },
+        );
 
         if emit_start_log {
             log_active_db_operation_contention("数据库操作开始时检测到", "数据库操作开始", &name, Some(id));
@@ -221,7 +224,10 @@ impl DbOperationGuard {
                 self.name, stage, elapsed_ms
             );
         } else {
-            debug!("数据库操作结束: op={}, stage={}, elapsed={}ms", self.name, stage, elapsed_ms);
+            debug!(
+                "数据库操作结束: op={}, stage={}, elapsed={}ms",
+                self.name, stage, elapsed_ms
+            );
         }
     }
 }
@@ -649,6 +655,40 @@ async fn ensure_ai_renamed_column(connection: &DatabaseConnection) -> Result<()>
     Ok(())
 }
 
+async fn ensure_danmaku_last_write_count_column(connection: &DatabaseConnection) -> Result<()> {
+    use sea_orm::ConnectionTrait;
+
+    let backend = connection.get_database_backend();
+
+    let check_sql = "SELECT COUNT(*) FROM pragma_table_info('page') WHERE name = 'danmaku_last_write_count'";
+    let result: Option<i32> = connection
+        .query_one(sea_orm::Statement::from_string(backend, check_sql))
+        .await?
+        .and_then(|row| row.try_get_by_index(0).ok());
+
+    if let Some(count) = result {
+        if count >= 1 {
+            debug!("page.danmaku_last_write_count 字段已存在");
+            return Ok(());
+        }
+    }
+
+    let add_sql = "ALTER TABLE page ADD COLUMN danmaku_last_write_count INTEGER NOT NULL DEFAULT 0";
+    match connection
+        .execute(sea_orm::Statement::from_string(backend, add_sql))
+        .await
+    {
+        Ok(_) => info!("成功添加 page.danmaku_last_write_count 字段"),
+        Err(e) => {
+            if !e.to_string().contains("duplicate column") {
+                return Err(e.into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// 预热数据库，将关键数据加载到内存映射中
 async fn preheat_database(connection: &DatabaseConnection) -> Result<()> {
     use sea_orm::ConnectionTrait;
@@ -703,6 +743,10 @@ pub async fn setup_database() -> DatabaseConnection {
     // 添加 page.ai_renamed 字段
     if let Err(e) = ensure_ai_renamed_column(&connection).await {
         tracing::warn!("添加 ai_renamed 字段失败: {}", e);
+    }
+
+    if let Err(e) = ensure_danmaku_last_write_count_column(&connection).await {
+        tracing::warn!("添加 danmaku_last_write_count 字段失败: {}", e);
     }
 
     // 预热数据库，加载热数据到内存映射
@@ -788,10 +832,7 @@ mod tests {
 
     impl Write for SharedLogWriter {
         fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .extend_from_slice(buf);
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).extend_from_slice(buf);
             Ok(buf.len())
         }
 
@@ -802,13 +843,7 @@ mod tests {
 
     impl SharedLogBuffer {
         fn contents(&self) -> String {
-            String::from_utf8(
-                self.0
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .clone(),
-            )
-            .unwrap_or_default()
+            String::from_utf8(self.0.lock().unwrap_or_else(|e| e.into_inner()).clone()).unwrap_or_default()
         }
     }
 
@@ -856,10 +891,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn traced_db_operation_skips_contention_warning_for_short_overlap() -> anyhow::Result<()> {
-        ACTIVE_DB_OPERATIONS
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clear();
+        ACTIVE_DB_OPERATIONS.lock().unwrap_or_else(|e| e.into_inner()).clear();
 
         let logs = SharedLogBuffer::default();
         let subscriber = tracing_subscriber::fmt()
@@ -870,16 +902,13 @@ mod tests {
             .finish();
         let _subscriber_guard = tracing::subscriber::set_default(subscriber);
 
-        ACTIVE_DB_OPERATIONS
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(
-                999,
-                ActiveDbOperation {
-                    name: "test.short_holder".to_string(),
-                    started_at: Instant::now() - std::time::Duration::from_millis(10),
-                },
-            );
+        ACTIVE_DB_OPERATIONS.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            999,
+            ActiveDbOperation {
+                name: "test.short_holder".to_string(),
+                started_at: Instant::now() - std::time::Duration::from_millis(10),
+            },
+        );
 
         run_traced_db_operation("test.short_contender", async { Ok::<_, anyhow::Error>(()) }).await?;
 
@@ -903,10 +932,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn traced_db_operation_logs_active_lock_holder_on_sqlite_lock() -> anyhow::Result<()> {
-        ACTIVE_DB_OPERATIONS
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clear();
+        ACTIVE_DB_OPERATIONS.lock().unwrap_or_else(|e| e.into_inner()).clear();
 
         let logs = SharedLogBuffer::default();
         let subscriber = tracing_subscriber::fmt()
@@ -926,7 +952,10 @@ mod tests {
             .await?;
 
         let lock_holder = begin_write_transaction(&connection_1, "test.lock_holder").await?;
-        tokio::time::sleep(std::time::Duration::from_millis((ACTIVE_DB_CONTENTION_WARN_MS + 20) as u64)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(
+            (ACTIVE_DB_CONTENTION_WARN_MS + 20) as u64,
+        ))
+        .await;
 
         let err = run_traced_db_operation("test.contender", async {
             connection_2

--- a/crates/bili_sync/src/main.rs
+++ b/crates/bili_sync/src/main.rs
@@ -18,6 +18,7 @@ mod task;
 mod unified_downloader;
 mod utils;
 mod workflow;
+mod workflow_danmaku;
 
 use std::fmt::Debug;
 use std::future::Future;

--- a/crates/bili_sync/src/task/http_server.rs
+++ b/crates/bili_sync/src/task/http_server.rs
@@ -62,7 +62,9 @@ use crate::api::handler::{
     poll_qr_status,
     proxy_image,
     proxy_video_stream,
+    refresh_page_danmaku,
     refresh_scanning_endpoint,
+    refresh_video_danmaku,
     reload_config,
     reload_config_new_internal,
     reset_all_videos,
@@ -199,8 +201,10 @@ pub async fn http_server(_database_connection: Arc<DatabaseConnection>) -> Resul
         .route("/api/videos/live", get(stream_videos))
         .route("/api/videos/{id}", get(get_video))
         .route("/api/videos/{id}", delete(delete_video))
+        .route("/api/videos/{id}/refresh-danmaku", post(refresh_video_danmaku))
         .route("/api/videos/{id}/reset", post(reset_video))
         .route("/api/videos/{id}/update-status", post(update_video_status))
+        .route("/api/pages/{id}/refresh-danmaku", post(refresh_page_danmaku))
         .route("/api/videos/reset-all", post(reset_all_videos))
         .route("/api/videos/reset-specific-tasks", post(reset_specific_tasks))
         .route("/api/dashboard", get(get_dashboard_data))

--- a/crates/bili_sync/src/task/mod.rs
+++ b/crates/bili_sync/src/task/mod.rs
@@ -95,6 +95,13 @@ pub struct UpdateConfigTask {
     pub danmaku_bold: Option<bool>,
     pub danmaku_outline: Option<f64>,
     pub danmaku_time_offset: Option<f64>,
+    pub danmaku_update_enabled: Option<bool>,
+    pub danmaku_update_fresh_days: Option<u32>,
+    pub danmaku_update_fresh_interval_hours: Option<u32>,
+    pub danmaku_update_mature_days: Option<u32>,
+    pub danmaku_update_mature_interval_days: Option<u32>,
+    pub danmaku_update_cold_days: Option<u32>,
+    pub danmaku_update_cold_interval_days: Option<u32>,
     // 并发控制设置
     pub concurrent_video: Option<usize>,
     pub concurrent_page: Option<usize>,
@@ -2081,6 +2088,13 @@ impl ConfigTaskQueue {
                 danmaku_bold: task.danmaku_bold,
                 danmaku_outline: task.danmaku_outline,
                 danmaku_time_offset: task.danmaku_time_offset,
+                danmaku_update_enabled: task.danmaku_update_enabled,
+                danmaku_update_fresh_days: task.danmaku_update_fresh_days,
+                danmaku_update_fresh_interval_hours: task.danmaku_update_fresh_interval_hours,
+                danmaku_update_mature_days: task.danmaku_update_mature_days,
+                danmaku_update_mature_interval_days: task.danmaku_update_mature_interval_days,
+                danmaku_update_cold_days: task.danmaku_update_cold_days,
+                danmaku_update_cold_interval_days: task.danmaku_update_cold_interval_days,
                 // 并发控制设置
                 concurrent_video: task.concurrent_video,
                 concurrent_page: task.concurrent_page,
@@ -2432,7 +2446,11 @@ mod tests {
         let controller = Arc::new(TaskController::new());
         let wait_controller = controller.clone();
 
-        let waiter = tokio::spawn(async move { wait_controller.wait_for_scan_signal_or_timeout(Duration::from_secs(5)).await });
+        let waiter = tokio::spawn(async move {
+            wait_controller
+                .wait_for_scan_signal_or_timeout(Duration::from_secs(5))
+                .await
+        });
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         controller.trigger_scan_now();

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -1203,6 +1203,13 @@ pub async fn video_downloader(connection: Arc<DatabaseConnection>) {
                 error!("处理配置任务队列失败: {:#}", e);
             }
 
+            let latest_config = crate::config::reload_config();
+            if let Err(e) =
+                crate::workflow_danmaku::refresh_danmaku_incremental(&bili_client, &connection, &latest_config).await
+            {
+                error!("执行弹幕增量更新失败: {:#}", e);
+            }
+
             // mmap自动处理数据持久化，不需要手动同步
         } else {
             debug!("任务已暂停，跳过后处理阶段");

--- a/crates/bili_sync/src/utils/danmaku_schedule.rs
+++ b/crates/bili_sync/src/utils/danmaku_schedule.rs
@@ -28,6 +28,16 @@ impl Stage {
     pub fn as_generation(self) -> u32 {
         self as u32
     }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Stage::Initial => "未同步",
+            Stage::Fresh => "新鲜期",
+            Stage::Mature => "成熟期",
+            Stage::Cold => "老化期",
+            Stage::Frozen => "已冻结",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -169,5 +179,14 @@ mod tests {
             ),
             Decision::Skip
         );
+    }
+
+    #[test]
+    fn stage_label_returns_chinese_text() {
+        assert_eq!(Stage::Initial.label(), "未同步");
+        assert_eq!(Stage::Fresh.label(), "新鲜期");
+        assert_eq!(Stage::Mature.label(), "成熟期");
+        assert_eq!(Stage::Cold.label(), "老化期");
+        assert_eq!(Stage::Frozen.label(), "已冻结");
     }
 }

--- a/crates/bili_sync/src/utils/danmaku_schedule.rs
+++ b/crates/bili_sync/src/utils/danmaku_schedule.rs
@@ -1,0 +1,173 @@
+//! 弹幕增量更新的调度决策函数（纯函数，易测试）。
+
+use chrono::{DateTime, Duration, Utc};
+
+use crate::config::DanmakuUpdatePolicy;
+
+/// 弹幕同步阶段（与数据库 `page.danmaku_sync_generation` 字段一一对应）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    Initial = 0,
+    Fresh = 1,
+    Mature = 2,
+    Cold = 3,
+    Frozen = 4,
+}
+
+impl Stage {
+    pub fn from_generation(generation: u32) -> Self {
+        match generation {
+            0 => Stage::Initial,
+            1 => Stage::Fresh,
+            2 => Stage::Mature,
+            3 => Stage::Cold,
+            _ => Stage::Frozen,
+        }
+    }
+
+    pub fn as_generation(self) -> u32 {
+        self as u32
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    Skip,
+    Sync { next_stage: Stage },
+}
+
+pub fn stage_for_age(
+    policy: &DanmakuUpdatePolicy,
+    pubtime: DateTime<Utc>,
+    now: DateTime<Utc>,
+    allow_freeze: bool,
+) -> Stage {
+    let age = now.signed_duration_since(pubtime).max(Duration::zero());
+    let fresh_end = Duration::days(policy.fresh_days as i64);
+    let mature_end = Duration::days(policy.mature_days as i64);
+    let cold_end = Duration::days(policy.cold_days as i64);
+
+    if allow_freeze && age >= cold_end {
+        Stage::Frozen
+    } else if age < fresh_end {
+        Stage::Fresh
+    } else if age < mature_end {
+        Stage::Mature
+    } else {
+        Stage::Cold
+    }
+}
+
+pub fn should_sync_danmaku(
+    policy: &DanmakuUpdatePolicy,
+    pubtime: DateTime<Utc>,
+    last_synced: Option<DateTime<Utc>>,
+    generation: u32,
+    now: DateTime<Utc>,
+) -> Decision {
+    if !policy.enabled {
+        return Decision::Skip;
+    }
+
+    let current_stage = Stage::from_generation(generation);
+    if current_stage == Stage::Frozen {
+        return Decision::Skip;
+    }
+
+    let target_stage = stage_for_age(policy, pubtime, now, true);
+    if target_stage == Stage::Frozen {
+        return Decision::Sync {
+            next_stage: Stage::Frozen,
+        };
+    }
+
+    let interval = match target_stage {
+        Stage::Fresh => Duration::hours(policy.fresh_interval_hours as i64),
+        Stage::Mature => Duration::days(policy.mature_interval_days as i64),
+        Stage::Cold => Duration::days(policy.cold_interval_days as i64),
+        Stage::Initial | Stage::Frozen => Duration::zero(),
+    };
+
+    match last_synced {
+        None => Decision::Sync {
+            next_stage: target_stage,
+        },
+        Some(last_synced_at) => {
+            let since_last = now.signed_duration_since(last_synced_at);
+            if target_stage.as_generation() > current_stage.as_generation() {
+                return Decision::Sync {
+                    next_stage: target_stage,
+                };
+            }
+            if since_last >= interval {
+                Decision::Sync {
+                    next_stage: target_stage,
+                }
+            } else {
+                Decision::Skip
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> DanmakuUpdatePolicy {
+        DanmakuUpdatePolicy {
+            enabled: true,
+            fresh_days: 3,
+            fresh_interval_hours: 6,
+            mature_days: 30,
+            mature_interval_days: 3,
+            cold_days: 180,
+            cold_interval_days: 30,
+        }
+    }
+
+    fn t(days: i64, hours: i64) -> DateTime<Utc> {
+        DateTime::<Utc>::from_timestamp(0, 0).unwrap() + Duration::days(days) + Duration::hours(hours)
+    }
+
+    #[test]
+    fn disabled_always_skip() {
+        let mut policy = policy();
+        policy.enabled = false;
+        assert_eq!(should_sync_danmaku(&policy, t(0, 0), None, 0, t(10, 0)), Decision::Skip);
+    }
+
+    #[test]
+    fn first_sync_triggers() {
+        assert_eq!(
+            should_sync_danmaku(&policy(), t(0, 0), None, 0, t(0, 1)),
+            Decision::Sync {
+                next_stage: Stage::Fresh
+            }
+        );
+    }
+
+    #[test]
+    fn stage_transition_triggers_immediately() {
+        assert_eq!(
+            should_sync_danmaku(&policy(), t(0, 0), Some(t(0, 2)), Stage::Fresh.as_generation(), t(5, 0)),
+            Decision::Sync {
+                next_stage: Stage::Mature
+            }
+        );
+    }
+
+    #[test]
+    fn frozen_always_skips() {
+        assert_eq!(
+            should_sync_danmaku(
+                &policy(),
+                t(0, 0),
+                Some(t(200, 0)),
+                Stage::Frozen.as_generation(),
+                t(300, 0)
+            ),
+            Decision::Skip
+        );
+    }
+}

--- a/crates/bili_sync/src/utils/filenamify.rs
+++ b/crates/bili_sync/src/utils/filenamify.rs
@@ -39,7 +39,7 @@ pub fn filenamify_with_options<S: AsRef<str>>(input: S, preserve_template_separa
     // 全角字符映射
     let fullwidth_colon = regex!("："); // 全角冒号 → 半角冒号
     let fullwidth_space = regex!("　"); // 全角空格 → 半角空格
-    // 其他可能有问题的字符（保留中文括号/书名号，避免过度清洗）
+                                        // 其他可能有问题的字符（保留中文括号/书名号，避免过度清洗）
     let problematic_chars = regex!("[★☆♪♫♬♩♭♮♯※‖§¶°±×÷≈≠≤≥∞∴∵∠⊥∥∧∨∩∪⊂⊃⊆⊇∈∉∃∀]");
 
     let replacement = "_";
@@ -199,6 +199,9 @@ mod tests {
             filenamify("〖周深｜MV〗《异人之下之决战！碧游村》主题曲《冰凌花》MV正式上线！"),
             "〖周深｜MV〗《异人之下之决战！碧游村》主题曲《冰凌花》MV正式上线！"
         );
-        assert_eq!(filenamify("【合集】『标题』〔测试〕〈特别篇〉"), "【合集】『标题』〔测试〕〈特别篇〉");
+        assert_eq!(
+            filenamify("【合集】『标题』〔测试〕〈特别篇〉"),
+            "【合集】『标题』〔测试〕〈特别篇〉"
+        );
     }
 }

--- a/crates/bili_sync/src/utils/mod.rs
+++ b/crates/bili_sync/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod bangumi_cache;
 pub mod bangumi_name_extractor;
 pub mod collection_aggregate;
 pub mod convert;
+pub mod danmaku_schedule;
 pub mod deepseek_pow;
 pub mod deepseek_web;
 pub mod file_logger;

--- a/crates/bili_sync/src/utils/model.rs
+++ b/crates/bili_sync/src/utils/model.rs
@@ -1509,6 +1509,10 @@ mod tests {
             play_audio_streams: Set(None),
             play_subtitle_streams: Set(None),
             play_streams_updated_at: Set(None),
+            danmaku_last_synced_at: Set(None),
+            danmaku_sync_generation: Set(0),
+            danmaku_cid_snapshot: Set(None),
+            danmaku_last_write_count: Set(0),
             ai_renamed: NotSet,
         }
         .insert(db)

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -3188,6 +3188,10 @@ pub async fn download_video_pages(
                 play_audio_streams: None,
                 play_subtitle_streams: None,
                 play_streams_updated_at: None,
+                danmaku_last_synced_at: None,
+                danmaku_sync_generation: 0,
+                danmaku_cid_snapshot: None,
+                danmaku_last_write_count: 0,
                 ai_renamed: None,
             };
 
@@ -12245,6 +12249,10 @@ mod tests {
             play_audio_streams: None,
             play_subtitle_streams: None,
             play_streams_updated_at: None,
+            danmaku_last_synced_at: None,
+            danmaku_sync_generation: 0,
+            danmaku_cid_snapshot: None,
+            danmaku_last_write_count: 0,
             ai_renamed: Some(0),
         }
     }

--- a/crates/bili_sync/src/workflow_danmaku.rs
+++ b/crates/bili_sync/src/workflow_danmaku.rs
@@ -28,6 +28,70 @@ struct ExistingDanmakuCursor {
     known_source_ids: HashSet<String>,
 }
 
+fn is_bili_request_failed_with_codes(err: &anyhow::Error, codes: &[i64]) -> bool {
+    err.chain().any(|cause| {
+        cause.downcast_ref::<crate::bilibili::BiliError>().is_some_and(|e| match e {
+            crate::bilibili::BiliError::RequestFailed(code, _) => codes.contains(code),
+            _ => false,
+        })
+    })
+}
+
+fn should_fallback_to_stored_pages(err: &anyhow::Error) -> bool {
+    is_bili_request_failed_with_codes(err, &[-404, 62002, 62012])
+}
+
+fn build_stored_page_info(page_model: &page::Model) -> Result<BiliPageInfo> {
+    let cid = page_model.danmaku_cid_snapshot.unwrap_or(page_model.cid);
+    if cid <= 0 {
+        bail!("分页 pid={} 缺少可用 cid，无法回退到数据库分页信息刷新弹幕", page_model.pid);
+    }
+
+    let dimension = match (page_model.width, page_model.height) {
+        (Some(width), Some(height)) => Some(Dimension {
+            width,
+            height,
+            rotate: 0,
+        }),
+        _ => None,
+    };
+
+    Ok(BiliPageInfo {
+        cid,
+        page: page_model.pid,
+        name: page_model.name.clone(),
+        duration: page_model.duration,
+        first_frame: None,
+        dimension,
+    })
+}
+
+async fn load_fresh_pages_or_fallback(
+    bili_video: &Video<'_>,
+    video_model: &video::Model,
+    db_pages: &[page::Model],
+    error_context: &str,
+) -> Result<Vec<BiliPageInfo>> {
+    match bili_video.get_view_info().await {
+        Ok(VideoInfo::Detail { pages, .. }) => Ok(pages),
+        Ok(_) => {
+            warn!(
+                "视频「{}」({}) 的 view_info 返回了非 Detail 类型，改用数据库已存分页信息继续刷新弹幕",
+                video_model.name, video_model.bvid
+            );
+            db_pages.iter().map(build_stored_page_info).collect()
+        }
+        Err(err) if should_fallback_to_stored_pages(&err) => {
+            warn!(
+                "视频「{}」({}) 获取 view_info 失败，改用数据库已存分页信息继续刷新弹幕：{:#}",
+                video_model.name, video_model.bvid, err
+            );
+            db_pages.iter().map(build_stored_page_info).collect()
+        }
+        Err(err) => Err(err).with_context(|| error_context.to_string()),
+    }
+}
+
 pub async fn refresh_danmaku_incremental(
     bili_client: &BiliClient,
     connection: &DatabaseConnection,
@@ -129,13 +193,13 @@ pub async fn refresh_danmaku_for_page(
         .ok_or_else(|| anyhow!("page {} 的宿主 video 不存在", page_id))?;
 
     let bili_video = Video::new(bili_client, video_model.bvid.clone());
-    let view_info = bili_video
-        .get_view_info()
-        .await
-        .with_context(|| format!("获取视频 {} 的 view_info 失败", video_model.bvid))?;
-    let VideoInfo::Detail { pages: fresh_pages, .. } = view_info else {
-        bail!("view_info 返回了非 Detail 类型，无法刷新弹幕");
-    };
+    let fresh_pages = load_fresh_pages_or_fallback(
+        &bili_video,
+        &video_model,
+        std::slice::from_ref(&page_model),
+        &format!("获取视频 {} 的 view_info 失败", video_model.bvid),
+    )
+    .await?;
     let fresh = fresh_pages
         .iter()
         .find(|page_info| page_info.page == page_model.pid)
@@ -295,13 +359,17 @@ async fn refresh_video_pages(
     now: DateTime<Utc>,
 ) -> Result<usize> {
     let bili_video = Video::new(bili_client, video_model.bvid.clone());
-    let view_info = bili_video
-        .get_view_info()
-        .await
-        .with_context(|| format!("刷新视频 {} 时获取 view_info 失败", video_model.bvid))?;
-    let VideoInfo::Detail { pages: fresh_pages, .. } = view_info else {
-        bail!("view_info 返回了非 Detail 类型，无法刷新弹幕");
-    };
+    let selected_pages = selected
+        .iter()
+        .map(|(page_model, _)| page_model.clone())
+        .collect::<Vec<_>>();
+    let fresh_pages = load_fresh_pages_or_fallback(
+        &bili_video,
+        video_model,
+        &selected_pages,
+        &format!("刷新视频 {} 时获取 view_info 失败", video_model.bvid),
+    )
+    .await?;
 
     let mut success = 0usize;
     for (db_page, next_stage) in selected {
@@ -735,5 +803,11 @@ mod tests {
         assert_eq!(filtered.len(), 2);
         assert!(filtered.iter().any(|elem| elem.dmid_str == "101"));
         assert!(filtered.iter().any(|elem| elem.dmid_str == "102"));
+    }
+
+    #[test]
+    fn should_fallback_to_stored_pages_accepts_62012() {
+        let err = anyhow!(crate::bilibili::BiliError::RequestFailed(62012, "62012".to_string()));
+        assert!(should_fallback_to_stored_pages(&err));
     }
 }

--- a/crates/bili_sync/src/workflow_danmaku.rs
+++ b/crates/bili_sync/src/workflow_danmaku.rs
@@ -75,14 +75,14 @@ async fn load_fresh_pages_or_fallback(
     match bili_video.get_view_info().await {
         Ok(VideoInfo::Detail { pages, .. }) => Ok(pages),
         Ok(_) => {
-            warn!(
+            info!(
                 "视频「{}」({}) 的 view_info 返回了非 Detail 类型，改用数据库已存分页信息继续刷新弹幕",
                 video_model.name, video_model.bvid
             );
             db_pages.iter().map(build_stored_page_info).collect()
         }
         Err(err) if should_fallback_to_stored_pages(&err) => {
-            warn!(
+            info!(
                 "视频「{}」({}) 获取 view_info 失败，改用数据库已存分页信息继续刷新弹幕：{:#}",
                 video_model.name, video_model.bvid, err
             );

--- a/crates/bili_sync/src/workflow_danmaku.rs
+++ b/crates/bili_sync/src/workflow_danmaku.rs
@@ -1,0 +1,739 @@
+//! 弹幕增量更新工作流。
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use bili_sync_entity::{collection, favorite, page, submission, video, video_source, watch_later};
+use chrono::{DateTime, TimeZone, Utc};
+use sea_orm::entity::prelude::*;
+use sea_orm::{ActiveModelTrait, Condition, QueryFilter, QuerySelect, Set};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+use crate::bilibili::{
+    parse_event_name, BiliClient, DanmakuElem, DanmakuWriter, Dimension, PageInfo as BiliPageInfo, Video, VideoInfo,
+};
+use crate::config::Config;
+use crate::utils::danmaku_schedule::{should_sync_danmaku, Decision, Stage};
+use crate::utils::status::STATUS_OK;
+use crate::utils::time_format::{beijing_timezone, parse_time_string, to_standard_string};
+
+/// 弹幕子任务在 download_status 中的位偏移（与 PageStatus 保持一致）。
+const DANMAKU_STATUS_OFFSET: usize = 3;
+
+#[derive(Debug, Default)]
+struct ExistingDanmakuCursor {
+    max_sent_at: Option<i64>,
+    known_source_ids: HashSet<String>,
+}
+
+pub async fn refresh_danmaku_incremental(
+    bili_client: &BiliClient,
+    connection: &DatabaseConnection,
+    config: &Config,
+) -> Result<()> {
+    if !config.danmaku_update_policy.enabled {
+        return Ok(());
+    }
+
+    info!("开始执行本轮弹幕增量更新");
+
+    let candidates = load_candidate_videos(connection).await?;
+    let now = Utc::now();
+    let mut processed = 0usize;
+    let mut refreshed = 0usize;
+
+    for (video_model, pages) in candidates {
+        let pubtime = stored_beijing_naive_to_utc(video_model.pubtime);
+        let selected = pages
+            .into_iter()
+            .filter_map(|page_model| {
+                let last_synced = page_model
+                    .danmaku_last_synced_at
+                    .as_deref()
+                    .and_then(parse_stored_datetime);
+
+                match should_sync_danmaku(
+                    &config.danmaku_update_policy,
+                    pubtime,
+                    last_synced,
+                    page_model.danmaku_sync_generation,
+                    now,
+                ) {
+                    Decision::Sync { next_stage } => Some((page_model, Some(next_stage))),
+                    Decision::Skip => None,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if selected.is_empty() {
+            continue;
+        }
+
+        match refresh_video_pages(bili_client, connection, config, &video_model, selected, now).await {
+            Ok(count) => {
+                processed += 1;
+                refreshed += count;
+            }
+            Err(err) => {
+                error!(
+                    "刷新视频「{}」({}) 的弹幕失败：{:#}",
+                    video_model.name, video_model.bvid, err
+                );
+            }
+        }
+    }
+
+    info!("弹幕增量更新结束：处理视频 {} 个，刷新分页 {} 个", processed, refreshed);
+    Ok(())
+}
+
+pub async fn refresh_danmaku_for_video(
+    video_id: i32,
+    bili_client: &BiliClient,
+    connection: &DatabaseConnection,
+    config: &Config,
+) -> Result<usize> {
+    let video_model = video::Entity::find_by_id(video_id)
+        .one(connection)
+        .await?
+        .ok_or_else(|| anyhow!("video {} 不存在", video_id))?;
+    let pages = page::Entity::find()
+        .filter(page::Column::VideoId.eq(video_id))
+        .all(connection)
+        .await?;
+
+    if pages.is_empty() {
+        return Ok(0);
+    }
+
+    let now = Utc::now();
+    let selected = pages.into_iter().map(|page_model| (page_model, None)).collect();
+    refresh_video_pages(bili_client, connection, config, &video_model, selected, now).await
+}
+
+pub async fn refresh_danmaku_for_page(
+    page_id: i32,
+    bili_client: &BiliClient,
+    connection: &DatabaseConnection,
+    config: &Config,
+) -> Result<usize> {
+    let page_model = page::Entity::find_by_id(page_id)
+        .one(connection)
+        .await?
+        .ok_or_else(|| anyhow!("page {} 不存在", page_id))?;
+    let video_model = video::Entity::find_by_id(page_model.video_id)
+        .one(connection)
+        .await?
+        .ok_or_else(|| anyhow!("page {} 的宿主 video 不存在", page_id))?;
+
+    let bili_video = Video::new(bili_client, video_model.bvid.clone());
+    let view_info = bili_video
+        .get_view_info()
+        .await
+        .with_context(|| format!("获取视频 {} 的 view_info 失败", video_model.bvid))?;
+    let VideoInfo::Detail { pages: fresh_pages, .. } = view_info else {
+        bail!("view_info 返回了非 Detail 类型，无法刷新弹幕");
+    };
+    let fresh = fresh_pages
+        .iter()
+        .find(|page_info| page_info.page == page_model.pid)
+        .ok_or_else(|| {
+            anyhow!(
+                "视频「{}」({}) 的分页 pid={} 在最新 view_info 中已不存在",
+                video_model.name,
+                video_model.bvid,
+                page_model.pid
+            )
+        })?;
+
+    refresh_one_page(
+        &bili_video,
+        connection,
+        config,
+        &video_model,
+        page_model,
+        fresh,
+        None,
+        Utc::now(),
+    )
+    .await?;
+
+    Ok(1)
+}
+
+async fn load_candidate_videos(connection: &DatabaseConnection) -> Result<Vec<(video::Model, Vec<page::Model>)>> {
+    let favorite_ids: Vec<i32> = favorite::Entity::find()
+        .filter(favorite::Column::Enabled.eq(true))
+        .filter(favorite::Column::DownloadDanmaku.eq(true))
+        .select_only()
+        .column(favorite::Column::Id)
+        .into_tuple()
+        .all(connection)
+        .await
+        .context("加载启用的收藏夹源失败")?;
+    let collection_ids: Vec<i32> = collection::Entity::find()
+        .filter(collection::Column::Enabled.eq(true))
+        .filter(collection::Column::DownloadDanmaku.eq(true))
+        .select_only()
+        .column(collection::Column::Id)
+        .into_tuple()
+        .all(connection)
+        .await
+        .context("加载启用的合集源失败")?;
+    let submission_ids: Vec<i32> = submission::Entity::find()
+        .filter(submission::Column::Enabled.eq(true))
+        .filter(submission::Column::DownloadDanmaku.eq(true))
+        .select_only()
+        .column(submission::Column::Id)
+        .into_tuple()
+        .all(connection)
+        .await
+        .context("加载启用的投稿源失败")?;
+    let watch_later_ids: Vec<i32> = watch_later::Entity::find()
+        .filter(watch_later::Column::Enabled.eq(true))
+        .filter(watch_later::Column::DownloadDanmaku.eq(true))
+        .select_only()
+        .column(watch_later::Column::Id)
+        .into_tuple()
+        .all(connection)
+        .await
+        .context("加载启用的稍后再看源失败")?;
+    let bangumi_ids: Vec<i32> = video_source::Entity::find()
+        .filter(video_source::Column::Type.eq(1))
+        .filter(video_source::Column::Enabled.eq(true))
+        .filter(video_source::Column::DownloadDanmaku.eq(true))
+        .select_only()
+        .column(video_source::Column::Id)
+        .into_tuple()
+        .all(connection)
+        .await
+        .context("加载启用的番剧源失败")?;
+
+    if favorite_ids.is_empty()
+        && collection_ids.is_empty()
+        && submission_ids.is_empty()
+        && watch_later_ids.is_empty()
+        && bangumi_ids.is_empty()
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut source_filter = Condition::any();
+    if !favorite_ids.is_empty() {
+        source_filter = source_filter.add(video::Column::FavoriteId.is_in(favorite_ids));
+    }
+    if !collection_ids.is_empty() {
+        source_filter = source_filter.add(video::Column::CollectionId.is_in(collection_ids));
+    }
+    if !submission_ids.is_empty() {
+        source_filter = source_filter.add(video::Column::SubmissionId.is_in(submission_ids));
+    }
+    if !watch_later_ids.is_empty() {
+        source_filter = source_filter.add(video::Column::WatchLaterId.is_in(watch_later_ids));
+    }
+    if !bangumi_ids.is_empty() {
+        source_filter = source_filter.add(
+            Condition::all()
+                .add(video::Column::SourceType.eq(1))
+                .add(video::Column::SourceId.is_in(bangumi_ids)),
+        );
+    }
+
+    video::Entity::find()
+        .filter(Condition::all().add(video::Column::Valid.eq(true)).add(source_filter))
+        .find_with_related(page::Entity)
+        .all(connection)
+        .await
+        .context("加载弹幕增量更新候选视频失败")
+        .map(|rows| {
+            rows.into_iter()
+                .map(|(video_model, pages)| {
+                    let filtered_pages = pages
+                        .into_iter()
+                        .filter(|page_model| {
+                            danmaku_subtask_completed(page_model.download_status)
+                                && page_model.path.as_deref().is_some_and(|path| !path.is_empty())
+                        })
+                        .collect::<Vec<_>>();
+                    (video_model, filtered_pages)
+                })
+                .filter(|(_, pages)| !pages.is_empty())
+                .collect()
+        })
+}
+
+fn danmaku_subtask_completed(status: u32) -> bool {
+    let slot = (status >> (DANMAKU_STATUS_OFFSET * 3)) & 0b111;
+    slot == STATUS_OK
+}
+
+fn reset_non_danmaku_subtasks(status: u32) -> u32 {
+    let mut next_status = status;
+    for offset in 0..5 {
+        if offset == DANMAKU_STATUS_OFFSET {
+            continue;
+        }
+        next_status &= !(0b111 << (offset * 3));
+    }
+    next_status & !(1 << 31)
+}
+
+fn reset_video_for_page_redownload(status: u32) -> u32 {
+    const PAGE_DOWNLOAD_OFFSET: usize = 4;
+    let cleared = status & !(0b111 << (PAGE_DOWNLOAD_OFFSET * 3));
+    cleared & !(1 << 31)
+}
+
+async fn refresh_video_pages(
+    bili_client: &BiliClient,
+    connection: &DatabaseConnection,
+    config: &Config,
+    video_model: &video::Model,
+    selected: Vec<(page::Model, Option<Stage>)>,
+    now: DateTime<Utc>,
+) -> Result<usize> {
+    let bili_video = Video::new(bili_client, video_model.bvid.clone());
+    let view_info = bili_video
+        .get_view_info()
+        .await
+        .with_context(|| format!("刷新视频 {} 时获取 view_info 失败", video_model.bvid))?;
+    let VideoInfo::Detail { pages: fresh_pages, .. } = view_info else {
+        bail!("view_info 返回了非 Detail 类型，无法刷新弹幕");
+    };
+
+    let mut success = 0usize;
+    for (db_page, next_stage) in selected {
+        let fresh = fresh_pages.iter().find(|page_info| page_info.page == db_page.pid);
+        let Some(fresh) = fresh else {
+            warn!(
+                "视频「{}」({}) 的分页 pid={} 在最新 view_info 中不存在，跳过",
+                video_model.name, video_model.bvid, db_page.pid
+            );
+            continue;
+        };
+
+        if let Err(err) = refresh_one_page(
+            &bili_video,
+            connection,
+            config,
+            video_model,
+            db_page,
+            fresh,
+            next_stage,
+            now,
+        )
+        .await
+        {
+            error!(
+                "刷新视频「{}」({}) 分页 pid={} 弹幕失败：{:#}",
+                video_model.name, video_model.bvid, fresh.page, err
+            );
+            continue;
+        }
+        success += 1;
+    }
+
+    Ok(success)
+}
+
+async fn refresh_one_page(
+    bili_video: &Video<'_>,
+    connection: &DatabaseConnection,
+    config: &Config,
+    video_model: &video::Model,
+    db_page: page::Model,
+    fresh: &BiliPageInfo,
+    next_stage: Option<Stage>,
+    now: DateTime<Utc>,
+) -> Result<()> {
+    if fresh.cid <= 0 {
+        bail!("分页 pid={} 返回了无效 cid", fresh.page);
+    }
+
+    let pubtime = stored_beijing_naive_to_utc(video_model.pubtime);
+    let resolved_stage = next_stage.unwrap_or_else(|| {
+        crate::utils::danmaku_schedule::stage_for_age(&config.danmaku_update_policy, pubtime, now, false)
+    });
+    let danmaku_path = resolve_danmaku_path(&db_page)?;
+    let (fresh_width, fresh_height) = extract_dimension(fresh.dimension.as_ref());
+    let fresh_duration = if fresh.duration > 0 {
+        fresh.duration
+    } else {
+        db_page.duration
+    };
+    let fresh_name = if fresh.name.is_empty() {
+        db_page.name.clone()
+    } else {
+        fresh.name.clone()
+    };
+
+    let cid_changed = db_page.cid != fresh.cid;
+    let duration_changed = db_page.duration != fresh_duration;
+    let dimension_changed = fresh_width != db_page.width || fresh_height != db_page.height;
+    let name_changed = db_page.name != fresh_name;
+
+    if cid_changed {
+        warn!(
+            "检测到视频「{}」({}) 分页 pid={} 的 cid 发生变化 ({} -> {})，已重置相关下载状态",
+            video_model.name, video_model.bvid, fresh.page, db_page.cid, fresh.cid
+        );
+    }
+
+    let page_info_for_danmaku = BiliPageInfo {
+        cid: fresh.cid,
+        page: fresh.page,
+        name: fresh_name.clone(),
+        duration: fresh_duration,
+        first_frame: fresh.first_frame.clone(),
+        dimension: fresh.dimension.as_ref().map(|dimension| Dimension {
+            width: dimension.width,
+            height: dimension.height,
+            rotate: dimension.rotate,
+        }),
+    };
+
+    let last_synced = db_page
+        .danmaku_last_synced_at
+        .as_deref()
+        .and_then(parse_stored_datetime);
+    let danmaku_elems = bili_video
+        .get_danmaku_elements(&page_info_for_danmaku, CancellationToken::new())
+        .await?;
+    let file_exists = tokio::fs::metadata(&danmaku_path).await.is_ok();
+    let fetched_danmaku_count = danmaku_elems.len() as u32;
+    let last_write_count = if file_exists && !cid_changed {
+        let existing_cursor = load_existing_danmaku_cursor(&danmaku_path).await?;
+        let cutoff = incremental_cutoff_timestamp(&danmaku_path, last_synced, &existing_cursor).await?;
+        let incremental_elems = filter_incremental_danmaku(danmaku_elems, cutoff, &existing_cursor);
+        let incremental_count = incremental_elems.len() as u32;
+        if !incremental_elems.is_empty() {
+            let writer = DanmakuWriter::new(
+                &page_info_for_danmaku,
+                incremental_elems.into_iter().map(Into::into).collect(),
+            );
+            writer.append(danmaku_path.clone()).await?;
+        }
+        incremental_count
+    } else {
+        let tmp_path = make_tmp_path(&danmaku_path);
+        let writer = DanmakuWriter::new(
+            &page_info_for_danmaku,
+            danmaku_elems.into_iter().map(Into::into).collect(),
+        );
+        writer.write(tmp_path.clone()).await?;
+        tokio::fs::rename(&tmp_path, &danmaku_path)
+            .await
+            .with_context(|| format!("重命名弹幕文件 {:?} -> {:?} 失败", tmp_path, danmaku_path))?;
+        fetched_danmaku_count
+    };
+
+    let now_str = to_standard_string(now.with_timezone(&beijing_timezone()));
+    let mut active: page::ActiveModel = db_page.clone().into();
+    active.danmaku_last_synced_at = Set(Some(now_str));
+    active.danmaku_sync_generation = Set(resolved_stage.as_generation());
+    active.danmaku_cid_snapshot = Set(Some(fresh.cid));
+    active.danmaku_last_write_count = Set(last_write_count);
+
+    if cid_changed {
+        active.cid = Set(fresh.cid);
+        active.download_status = Set(reset_non_danmaku_subtasks(db_page.download_status));
+        active.file_size_bytes = Set(None);
+        active.video_stream_size_bytes = Set(None);
+        active.audio_stream_size_bytes = Set(None);
+        active.play_video_streams = Set(None);
+        active.play_audio_streams = Set(None);
+        active.play_subtitle_streams = Set(None);
+        active.play_streams_updated_at = Set(None);
+
+        let mut video_active: video::ActiveModel = video_model.clone().into();
+        let new_video_status = reset_video_for_page_redownload(video_model.download_status);
+        let mut should_update_video = false;
+        if new_video_status != video_model.download_status {
+            video_active.download_status = Set(new_video_status);
+            should_update_video = true;
+        }
+        if video_model.single_page == Some(true) && video_model.cid != Some(fresh.cid) {
+            video_active.cid = Set(Some(fresh.cid));
+            should_update_video = true;
+        }
+        if should_update_video {
+            video_active
+                .update(connection)
+                .await
+                .context("cid 变化后更新 video 状态失败")?;
+        }
+    }
+
+    if duration_changed {
+        active.duration = Set(fresh_duration);
+    }
+    if dimension_changed {
+        active.width = Set(fresh_width);
+        active.height = Set(fresh_height);
+    }
+    if name_changed {
+        active.name = Set(fresh_name);
+    }
+
+    active.update(connection).await.context("更新 page 弹幕同步状态失败")?;
+
+    info!(
+        "视频「{}」({}) 分页 pid={} 弹幕已刷新 -> stage={:?}",
+        video_model.name, video_model.bvid, fresh.page, resolved_stage
+    );
+
+    Ok(())
+}
+
+fn extract_dimension(dimension: Option<&Dimension>) -> (Option<u32>, Option<u32>) {
+    match dimension {
+        Some(dimension) if dimension.rotate == 0 => (Some(dimension.width), Some(dimension.height)),
+        Some(dimension) => (Some(dimension.height), Some(dimension.width)),
+        None => (None, None),
+    }
+}
+
+fn resolve_danmaku_path(page_model: &page::Model) -> Result<PathBuf> {
+    let video_path = page_model
+        .path
+        .as_deref()
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| anyhow!("page 未记录下载路径，无法推断弹幕位置"))?;
+    let video_path = Path::new(video_path);
+    let parent = video_path.parent().context("invalid page path format")?;
+    let file_stem = video_path
+        .file_stem()
+        .context("invalid page path format")?
+        .to_string_lossy();
+    Ok(parent.join(format!("{}.zh-CN.default.ass", file_stem)))
+}
+
+fn make_tmp_path(target: &Path) -> PathBuf {
+    let mut value = target.as_os_str().to_os_string();
+    value.push(".tmp");
+    PathBuf::from(value)
+}
+
+async fn load_existing_danmaku_cursor(path: &Path) -> Result<ExistingDanmakuCursor> {
+    let content = String::from_utf8_lossy(&tokio::fs::read(path).await?).into_owned();
+    Ok(parse_existing_danmaku_cursor(&content))
+}
+
+fn parse_existing_danmaku_cursor(content: &str) -> ExistingDanmakuCursor {
+    let mut cursor = ExistingDanmakuCursor::default();
+    for line in content.lines() {
+        let Some(value) = line.strip_prefix("Dialogue: ") else {
+            continue;
+        };
+        let mut columns = value.splitn(10, ',');
+        let _layer = columns.next();
+        let _start = columns.next();
+        let _end = columns.next();
+        let _style = columns.next();
+        let Some(name) = columns.next() else {
+            continue;
+        };
+        if let Some((source_id, sent_at)) = parse_event_name(name) {
+            cursor.max_sent_at = Some(cursor.max_sent_at.map_or(sent_at, |current| current.max(sent_at)));
+            cursor.known_source_ids.insert(source_id.to_string());
+        }
+    }
+    cursor
+}
+
+async fn incremental_cutoff_timestamp(
+    danmaku_path: &Path,
+    last_synced: Option<DateTime<Utc>>,
+    existing_cursor: &ExistingDanmakuCursor,
+) -> Result<Option<i64>> {
+    let mut cutoff = last_synced.map(|value| value.timestamp());
+    if let Some(max_sent_at) = existing_cursor.max_sent_at {
+        cutoff = Some(cutoff.map_or(max_sent_at, |value| value.max(max_sent_at)));
+    }
+    if cutoff.is_some() {
+        return Ok(cutoff);
+    }
+
+    let modified = tokio::fs::metadata(danmaku_path)
+        .await?
+        .modified()
+        .ok()
+        .map(DateTime::<Utc>::from)
+        .map(|value| value.timestamp());
+    Ok(modified)
+}
+
+fn filter_incremental_danmaku(
+    danmaku_elems: Vec<DanmakuElem>,
+    cutoff: Option<i64>,
+    existing_cursor: &ExistingDanmakuCursor,
+) -> Vec<DanmakuElem> {
+    danmaku_elems
+        .into_iter()
+        .filter(|elem| {
+            let Some(source_id) = normalized_source_id(elem) else {
+                return match cutoff {
+                    Some(value) => elem.ctime > value,
+                    None => true,
+                };
+            };
+            if existing_cursor.known_source_ids.contains(&source_id) {
+                return false;
+            }
+
+            match cutoff {
+                Some(value) if elem.ctime > value => true,
+                Some(value) if existing_cursor.max_sent_at == Some(value) && elem.ctime == value => true,
+                Some(_) => false,
+                None => true,
+            }
+        })
+        .collect()
+}
+
+fn normalized_source_id(elem: &DanmakuElem) -> Option<String> {
+    if !elem.dmid_str.is_empty() {
+        Some(elem.dmid_str.clone())
+    } else if elem.id > 0 {
+        Some(elem.id.to_string())
+    } else {
+        None
+    }
+}
+
+fn stored_beijing_naive_to_utc(value: chrono::NaiveDateTime) -> DateTime<Utc> {
+    beijing_timezone()
+        .from_local_datetime(&value)
+        .single()
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|| Utc.from_utc_datetime(&value))
+}
+
+fn parse_stored_datetime(value: &str) -> Option<DateTime<Utc>> {
+    parse_time_string(value).map(stored_beijing_naive_to_utc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn danmaku_completed_detects_ok() {
+        let with_danmaku_ok: u32 = STATUS_OK << 9;
+        assert!(danmaku_subtask_completed(with_danmaku_ok));
+        let without: u32 = STATUS_OK << 6;
+        assert!(!danmaku_subtask_completed(without));
+    }
+
+    #[test]
+    fn reset_non_danmaku_subtasks_keeps_only_danmaku_ok() {
+        let all_ok_completed: u32 = (1u32 << 31)
+            | (0..5)
+                .map(|index| STATUS_OK << (index * 3))
+                .fold(0u32, |acc, value| acc | value);
+        let reset = reset_non_danmaku_subtasks(all_ok_completed);
+        assert_eq!((reset >> 9) & 0b111, STATUS_OK);
+        for index in [0usize, 1, 2, 4] {
+            assert_eq!((reset >> (index * 3)) & 0b111, 0);
+        }
+        assert_eq!(reset >> 31, 0);
+    }
+
+    #[test]
+    fn reset_video_for_page_redownload_clears_page_download_and_completed_bit() {
+        let video_done: u32 = (1u32 << 31)
+            | (0..5)
+                .map(|index| STATUS_OK << (index * 3))
+                .fold(0u32, |acc, value| acc | value);
+        let reset = reset_video_for_page_redownload(video_done);
+        assert_eq!((reset >> 12) & 0b111, 0);
+        for index in [0usize, 1, 2, 3] {
+            assert_eq!((reset >> (index * 3)) & 0b111, STATUS_OK);
+        }
+        assert_eq!(reset >> 31, 0);
+    }
+
+    #[test]
+    fn parse_stored_datetime_uses_beijing_timezone() {
+        let parsed = parse_stored_datetime("2026-04-13 10:20:30").expect("parse ok");
+        assert_eq!(parsed, Utc.with_ymd_and_hms(2026, 4, 13, 2, 20, 30).unwrap());
+    }
+
+    #[test]
+    fn parse_existing_danmaku_cursor_collects_metadata() {
+        let cursor = parse_existing_danmaku_cursor(
+            "[Events]\n\
+             Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n\
+             Dialogue: 2,0:00:01.00,0:00:05.00,Float,bsync-dm|100|1710000000,0,0,0,,foo\n\
+             Dialogue: 2,0:00:02.00,0:00:06.00,Float,bsync-dm|101|1710001234,0,0,0,,bar\n",
+        );
+        assert_eq!(cursor.max_sent_at, Some(1710001234));
+        assert!(cursor.known_source_ids.contains("100"));
+        assert!(cursor.known_source_ids.contains("101"));
+    }
+
+    #[test]
+    fn filter_incremental_danmaku_uses_cutoff_and_dedup() {
+        let existing_cursor = ExistingDanmakuCursor {
+            max_sent_at: Some(1710000100),
+            known_source_ids: ["100".to_string()].into_iter().collect(),
+        };
+        let filtered = filter_incremental_danmaku(
+            vec![
+                DanmakuElem {
+                    id: 100,
+                    progress: 1000,
+                    mode: 1,
+                    fontsize: 25,
+                    color: 0xffffff,
+                    mid_hash: String::new(),
+                    content: "old".to_string(),
+                    ctime: 1710000000,
+                    weight: 0,
+                    action: String::new(),
+                    pool: 0,
+                    dmid_str: "100".to_string(),
+                    attr: 0,
+                },
+                DanmakuElem {
+                    id: 101,
+                    progress: 1200,
+                    mode: 1,
+                    fontsize: 25,
+                    color: 0xffffff,
+                    mid_hash: String::new(),
+                    content: "same-second-new".to_string(),
+                    ctime: 1710000100,
+                    weight: 0,
+                    action: String::new(),
+                    pool: 0,
+                    dmid_str: "101".to_string(),
+                    attr: 0,
+                },
+                DanmakuElem {
+                    id: 102,
+                    progress: 1300,
+                    mode: 1,
+                    fontsize: 25,
+                    color: 0xffffff,
+                    mid_hash: String::new(),
+                    content: "new".to_string(),
+                    ctime: 1710000200,
+                    weight: 0,
+                    action: String::new(),
+                    pool: 0,
+                    dmid_str: "102".to_string(),
+                    attr: 0,
+                },
+            ],
+            Some(1710000100),
+            &existing_cursor,
+        );
+
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().any(|elem| elem.dmid_str == "101"));
+        assert!(filtered.iter().any(|elem| elem.dmid_str == "102"));
+    }
+}

--- a/crates/bili_sync/src/workflow_danmaku.rs
+++ b/crates/bili_sync/src/workflow_danmaku.rs
@@ -548,8 +548,11 @@ async fn refresh_one_page(
     active.update(connection).await.context("更新 page 弹幕同步状态失败")?;
 
     info!(
-        "视频「{}」({}) 分页 pid={} 弹幕已刷新 -> stage={:?}",
-        video_model.name, video_model.bvid, fresh.page, resolved_stage
+        "视频「{}」({}) 分页 pid={} 弹幕已刷新 -> 阶段={}",
+        video_model.name,
+        video_model.bvid,
+        fresh.page,
+        resolved_stage.label()
     );
 
     Ok(())

--- a/crates/bili_sync_entity/src/entities/page.rs
+++ b/crates/bili_sync_entity/src/entities/page.rs
@@ -25,6 +25,12 @@ pub struct Model {
     pub play_audio_streams: Option<String>,
     pub play_subtitle_streams: Option<String>,
     pub play_streams_updated_at: Option<String>,
+    pub danmaku_last_synced_at: Option<String>,
+    #[sea_orm(default_value = "0")]
+    pub danmaku_sync_generation: u32,
+    pub danmaku_cid_snapshot: Option<i64>,
+    #[sea_orm(default_value = "0")]
+    pub danmaku_last_write_count: u32,
     /// 是否已被 AI 重命名
     #[sea_orm(default_value = "0")]
     pub ai_renamed: Option<i32>,

--- a/crates/bili_sync_migration/src/lib.rs
+++ b/crates/bili_sync_migration/src/lib.rs
@@ -64,6 +64,7 @@ mod m20260308_000002_add_video_charge_flags;
 mod m20260314_000001_clear_image_proxy_image_data;
 mod m20260328_000001_add_scan_deleted_videos_once_field;
 mod m20260330_000001_add_video_file_size_fields;
+mod m20260414_000001_add_danmaku_sync_fields;
 
 pub struct Migrator;
 
@@ -135,6 +136,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260314_000001_clear_image_proxy_image_data::Migration),
             Box::new(m20260328_000001_add_scan_deleted_videos_once_field::Migration),
             Box::new(m20260330_000001_add_video_file_size_fields::Migration),
+            Box::new(m20260414_000001_add_danmaku_sync_fields::Migration),
         ]
     }
 }

--- a/crates/bili_sync_migration/src/m20260414_000001_add_danmaku_sync_fields.rs
+++ b/crates/bili_sync_migration/src/m20260414_000001_add_danmaku_sync_fields.rs
@@ -1,0 +1,154 @@
+use sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_column_if_missing(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_last_synced_at",
+            ColumnDef::new(Page::DanmakuLastSyncedAt).string().null().to_owned(),
+        )
+        .await?;
+
+        add_column_if_missing(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_sync_generation",
+            ColumnDef::new(Page::DanmakuSyncGeneration)
+                .unsigned()
+                .not_null()
+                .default(0)
+                .to_owned(),
+        )
+        .await?;
+
+        add_column_if_missing(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_cid_snapshot",
+            ColumnDef::new(Page::DanmakuCidSnapshot).big_integer().null().to_owned(),
+        )
+        .await?;
+
+        add_column_if_missing(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_last_write_count",
+            ColumnDef::new(Page::DanmakuLastWriteCount)
+                .unsigned()
+                .not_null()
+                .default(0)
+                .to_owned(),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        drop_column_if_exists(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_last_write_count",
+            Page::DanmakuLastWriteCount,
+        )
+        .await?;
+
+        drop_column_if_exists(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_cid_snapshot",
+            Page::DanmakuCidSnapshot,
+        )
+        .await?;
+
+        drop_column_if_exists(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_sync_generation",
+            Page::DanmakuSyncGeneration,
+        )
+        .await?;
+
+        drop_column_if_exists(
+            manager,
+            "page",
+            Page::Table,
+            "danmaku_last_synced_at",
+            Page::DanmakuLastSyncedAt,
+        )
+        .await
+    }
+}
+
+async fn add_column_if_missing<T>(
+    manager: &SchemaManager<'_>,
+    table_name: &str,
+    table: T,
+    column_name: &str,
+    column_def: ColumnDef,
+) -> Result<(), DbErr>
+where
+    T: IntoIden + Clone + 'static,
+{
+    if !table_has_column(manager, table_name, column_name).await? {
+        manager
+            .alter_table(Table::alter().table(table).add_column(column_def).to_owned())
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn drop_column_if_exists<T, C>(
+    manager: &SchemaManager<'_>,
+    table_name: &str,
+    table: T,
+    column_name: &str,
+    column: C,
+) -> Result<(), DbErr>
+where
+    T: IntoIden + Clone + 'static,
+    C: IntoIden + 'static,
+{
+    if table_has_column(manager, table_name, column_name).await? {
+        manager
+            .alter_table(Table::alter().table(table).drop_column(column).to_owned())
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn table_has_column(manager: &SchemaManager<'_>, table_name: &str, column_name: &str) -> Result<bool, DbErr> {
+    let backend = manager.get_connection().get_database_backend();
+    let sql = format!(
+        "SELECT COUNT(*) FROM pragma_table_info('{}') WHERE name = '{}'",
+        table_name.replace('\'', "''"),
+        column_name.replace('\'', "''")
+    );
+    let result = manager
+        .get_connection()
+        .query_one(Statement::from_string(backend, sql))
+        .await?;
+    Ok(result.and_then(|row| row.try_get_by_index(0).ok()).unwrap_or(0) >= 1)
+}
+
+#[derive(Iden, Clone)]
+enum Page {
+    Table,
+    DanmakuLastSyncedAt,
+    DanmakuSyncGeneration,
+    DanmakuCidSnapshot,
+    DanmakuLastWriteCount,
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
 	DeleteVideoSourceResponse,
 	DeleteVideoResponse,
 	ConfigResponse,
+	RefreshDanmakuResponse,
 	UpdateConfigRequest,
 	UpdateConfigResponse,
 	SearchRequest,
@@ -228,6 +229,14 @@ class ApiClient {
 	 */
 	async getVideo(id: number): Promise<ApiResponse<VideoResponse>> {
 		return this.get<VideoResponse>(`/videos/${id}`);
+	}
+
+	async refreshVideoDanmaku(id: number): Promise<ApiResponse<RefreshDanmakuResponse>> {
+		return this.post<RefreshDanmakuResponse>(`/videos/${id}/refresh-danmaku`);
+	}
+
+	async refreshPageDanmaku(id: number): Promise<ApiResponse<RefreshDanmakuResponse>> {
+		return this.post<RefreshDanmakuResponse>(`/pages/${id}/refresh-danmaku`);
 	}
 
 	/**
@@ -985,6 +994,10 @@ export const api = {
 	 * 获取单个视频详情
 	 */
 	getVideo: (id: number) => apiClient.getVideo(id),
+
+	refreshVideoDanmaku: (id: number) => apiClient.refreshVideoDanmaku(id),
+
+	refreshPageDanmaku: (id: number) => apiClient.refreshPageDanmaku(id),
 
 	/**
 	 * 重置视频下载状态

--- a/web/src/lib/consts.ts
+++ b/web/src/lib/consts.ts
@@ -12,4 +12,12 @@ export const VIDEO_SOURCES = {
 	BANGUMI: { type: 'bangumi', title: '番剧', icon: TvIcon }
 } as const;
 
+export const DANMAKU_SYNC_STAGE_LABELS: Record<number, string> = {
+	0: '未同步',
+	1: '新鲜期',
+	2: '成熟期',
+	3: '老化期',
+	4: '已冻结'
+};
+
 export type VideoSourceType = (typeof VIDEO_SOURCES)[keyof typeof VIDEO_SOURCES]['type'];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -116,6 +116,10 @@ export interface PageInfo {
 	name: string;
 	download_status: [number, number, number, number, number];
 	path?: string;
+	danmaku_last_synced_at?: string;
+	danmaku_sync_generation: number;
+	danmaku_cid_snapshot?: number;
+	danmaku_last_write_count: number;
 }
 
 // 单个视频响应类型
@@ -285,6 +289,13 @@ export interface ConfigResponse {
 	danmaku_bold?: boolean;
 	danmaku_outline?: number;
 	danmaku_time_offset?: number;
+	danmaku_update_enabled?: boolean;
+	danmaku_update_fresh_days?: number;
+	danmaku_update_fresh_interval_hours?: number;
+	danmaku_update_mature_days?: number;
+	danmaku_update_mature_interval_days?: number;
+	danmaku_update_cold_days?: number;
+	danmaku_update_cold_interval_days?: number;
 	// 新增并发控制设置
 	concurrent_video?: number;
 	concurrent_page?: number;
@@ -416,6 +427,13 @@ export interface UpdateConfigRequest {
 	danmaku_bold?: boolean;
 	danmaku_outline?: number;
 	danmaku_time_offset?: number;
+	danmaku_update_enabled?: boolean;
+	danmaku_update_fresh_days?: number;
+	danmaku_update_fresh_interval_hours?: number;
+	danmaku_update_mature_days?: number;
+	danmaku_update_mature_interval_days?: number;
+	danmaku_update_cold_days?: number;
+	danmaku_update_cold_interval_days?: number;
 	// 新增并发控制设置
 	concurrent_video?: number;
 	concurrent_page?: number;
@@ -497,6 +515,12 @@ export interface UpdateConfigResponse {
 	updated_files?: number;
 	resetted_nfo_videos_count?: number;
 	resetted_nfo_pages_count?: number;
+}
+
+export interface RefreshDanmakuResponse {
+	success: boolean;
+	refreshed_pages: number;
+	message: string;
 }
 
 // 搜索请求类型

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -165,6 +165,13 @@
 	let danmakuBold = true;
 	let danmakuOutline = 0.8;
 	let danmakuTimeOffset = 0.0;
+	let danmakuUpdateEnabled = false;
+	let danmakuUpdateFreshDays = 3;
+	let danmakuUpdateFreshIntervalHours = 6;
+	let danmakuUpdateMatureDays = 30;
+	let danmakuUpdateMatureIntervalDays = 3;
+	let danmakuUpdateColdDays = 180;
+	let danmakuUpdateColdIntervalDays = 30;
 
 	// 并发控制设置
 	let concurrentVideo = 3;
@@ -289,6 +296,17 @@
 
 	// 显示帮助信息的状态（在文件命名抽屉中使用）
 	let showHelp = false;
+
+	const danmakuUpdateHelp = {
+		section:
+			'已下载分页会按视频发布时间分阶段刷新弹幕。新鲜期刷新更频繁，成熟期和老化期逐步放缓，超过老化期后会进入冷冻阶段并停止后台轮询。',
+		freshDays: '视频发布后，落在这个天数范围内的分页会被视为新鲜期。',
+		freshIntervalHours: '新鲜期内后台检查弹幕更新的间隔，单位是小时。',
+		matureDays: '超过新鲜期、但还没达到这个天数的分页会进入成熟期。',
+		matureIntervalDays: '成熟期内后台检查弹幕更新的间隔，单位是天。',
+		coldDays: '超过成熟期、但还没达到这个天数的分页会进入老化期；再往后会停止后台轮询。',
+		coldIntervalDays: '老化期内后台检查弹幕更新的间隔，单位是天。'
+	};
 
 	// 验证相关状态
 	let pageNameError = '';
@@ -508,6 +526,13 @@
 		danmakuBold = config.danmaku_bold !== undefined ? config.danmaku_bold : true;
 		danmakuOutline = config.danmaku_outline || 0.8;
 		danmakuTimeOffset = config.danmaku_time_offset || 0.0;
+		danmakuUpdateEnabled = config.danmaku_update_enabled ?? false;
+		danmakuUpdateFreshDays = config.danmaku_update_fresh_days ?? 3;
+		danmakuUpdateFreshIntervalHours = config.danmaku_update_fresh_interval_hours ?? 6;
+		danmakuUpdateMatureDays = config.danmaku_update_mature_days ?? 30;
+		danmakuUpdateMatureIntervalDays = config.danmaku_update_mature_interval_days ?? 3;
+		danmakuUpdateColdDays = config.danmaku_update_cold_days ?? 180;
+		danmakuUpdateColdIntervalDays = config.danmaku_update_cold_interval_days ?? 30;
 
 		// 并发控制设置
 		concurrentVideo = config.concurrent_video || 3;
@@ -822,6 +847,13 @@
 			danmaku_bold: danmakuBold,
 			danmaku_outline: danmakuOutline,
 			danmaku_time_offset: danmakuTimeOffset,
+			danmaku_update_enabled: danmakuUpdateEnabled,
+			danmaku_update_fresh_days: danmakuUpdateFreshDays,
+			danmaku_update_fresh_interval_hours: danmakuUpdateFreshIntervalHours,
+			danmaku_update_mature_days: danmakuUpdateMatureDays,
+			danmaku_update_mature_interval_days: danmakuUpdateMatureIntervalDays,
+			danmaku_update_cold_days: danmakuUpdateColdDays,
+			danmaku_update_cold_interval_days: danmakuUpdateColdIntervalDays,
 			// 并发控制设置
 			concurrent_video: concurrentVideo,
 			concurrent_page: concurrentPage,
@@ -2138,6 +2170,127 @@
 						class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
 					/>
 					<Label for="danmaku-bold" class="text-sm">加粗字体</Label>
+				</div>
+			</div>
+
+			<div class="rounded-lg border p-4">
+				<div class="mb-4 flex items-center justify-between gap-3">
+					<div>
+						<h5 class="cursor-help font-medium" title={danmakuUpdateHelp.section}>弹幕增量更新</h5>
+						<p class="text-muted-foreground mt-1 text-sm">
+							按视频发布时间分阶段刷新已下载分页的弹幕，并在冷冻期后停止后台轮询。
+						</p>
+					</div>
+					<label class="flex items-center gap-2 text-sm">
+						<input
+							type="checkbox"
+							bind:checked={danmakuUpdateEnabled}
+							class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+						/>
+						<span>启用</span>
+					</label>
+				</div>
+
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<div class="space-y-2">
+						<Label for="danmaku-update-fresh-days" class="cursor-help" title={danmakuUpdateHelp.freshDays}
+							>新鲜期天数</Label
+						>
+						<Input
+							id="danmaku-update-fresh-days"
+							type="number"
+							bind:value={danmakuUpdateFreshDays}
+							min="0"
+							placeholder="3"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
+
+					<div class="space-y-2">
+						<Label
+							for="danmaku-update-fresh-hours"
+							class="cursor-help"
+							title={danmakuUpdateHelp.freshIntervalHours}
+						>
+							新鲜期刷新间隔（小时）
+						</Label>
+						<Input
+							id="danmaku-update-fresh-hours"
+							type="number"
+							bind:value={danmakuUpdateFreshIntervalHours}
+							min="1"
+							placeholder="6"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
+
+					<div class="space-y-2">
+						<Label
+							for="danmaku-update-mature-days"
+							class="cursor-help"
+							title={danmakuUpdateHelp.matureDays}
+						>
+							成熟期截至天数
+						</Label>
+						<Input
+							id="danmaku-update-mature-days"
+							type="number"
+							bind:value={danmakuUpdateMatureDays}
+							min="0"
+							placeholder="30"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
+
+					<div class="space-y-2">
+						<Label
+							for="danmaku-update-mature-interval"
+							class="cursor-help"
+							title={danmakuUpdateHelp.matureIntervalDays}
+						>
+							成熟期刷新间隔（天）
+						</Label>
+						<Input
+							id="danmaku-update-mature-interval"
+							type="number"
+							bind:value={danmakuUpdateMatureIntervalDays}
+							min="1"
+							placeholder="3"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
+
+					<div class="space-y-2">
+						<Label for="danmaku-update-cold-days" class="cursor-help" title={danmakuUpdateHelp.coldDays}
+							>老化期截至天数</Label
+						>
+						<Input
+							id="danmaku-update-cold-days"
+							type="number"
+							bind:value={danmakuUpdateColdDays}
+							min="0"
+							placeholder="180"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
+
+					<div class="space-y-2">
+						<Label
+							for="danmaku-update-cold-interval"
+							class="cursor-help"
+							title={danmakuUpdateHelp.coldIntervalDays}
+						>
+							老化期刷新间隔（天）
+						</Label>
+						<Input
+							id="danmaku-update-cold-interval"
+							type="number"
+							bind:value={danmakuUpdateColdIntervalDays}
+							min="1"
+							placeholder="30"
+							disabled={!danmakuUpdateEnabled}
+						/>
+					</div>
 				</div>
 			</div>
 

--- a/web/src/routes/video/[id]/+page.svelte
+++ b/web/src/routes/video/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import api from '$lib/api';
 	import StatusEditor from '$lib/components/status-editor.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
+	import { DANMAKU_SYNC_STAGE_LABELS } from '$lib/consts';
 	import VideoCard from '$lib/components/video-card.svelte';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
 	import {
@@ -21,6 +22,7 @@
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import EditIcon from '@lucide/svelte/icons/edit';
 	import PlayIcon from '@lucide/svelte/icons/play';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 	import XIcon from '@lucide/svelte/icons/x';
 	import { onMount } from 'svelte';
@@ -39,6 +41,8 @@
 	let onlinePlayMode = false; // false: 本地播放, true: B站内嵌播放
 	let deleteDialogOpen = false;
 	let deleting = false;
+	let refreshingVideoDanmaku = false;
+	let refreshingPageIds = new Set<number>();
 	let safePlayingPageIndex = 0;
 	let videoDetailLoadToken = 0;
 	let lastPlaybackNoticeKey: string | null = null;
@@ -85,6 +89,123 @@
 		}
 		if (!options?.keepPlayMode) {
 			onlinePlayMode = false;
+		}
+	}
+
+	function parseBeijingTimestamp(value?: string | null): Date | null {
+		if (!value) return null;
+		const match = value.match(
+			/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?$/
+		);
+		if (!match) return null;
+		const [, year, month, day, hour, minute, second] = match;
+		return new Date(
+			Date.UTC(
+				Number(year),
+				Number(month) - 1,
+				Number(day),
+				Number(hour) - 8,
+				Number(minute),
+				Number(second)
+			)
+		);
+	}
+
+	function getDanmakuStageLabel(generation: number) {
+		return DANMAKU_SYNC_STAGE_LABELS[generation] ?? '未知阶段';
+	}
+
+	function getDanmakuStageDescription(generation: number) {
+		switch (generation) {
+			case 1:
+				return '新鲜期会更频繁地检查弹幕更新，并按日期增量追加到文件。';
+			case 2:
+				return '成熟期会降低后台检查频率，继续按日期增量追加新弹幕。';
+			case 3:
+				return '老化期仍会定期检查弹幕更新，但频率会进一步放缓。';
+			case 4:
+				return '已冻结阶段不会再自动后台轮询，但仍然可以手动刷新弹幕。';
+			default:
+				return '当前分页还没有建立弹幕同步记录。';
+		}
+	}
+
+	function getDanmakuSyncTitle(generation: number, lastSyncedAt?: string | null) {
+		const stageLabel = getDanmakuStageLabel(generation);
+		const description = getDanmakuStageDescription(generation);
+		return lastSyncedAt ? `当前阶段：${stageLabel}。${description}` : `当前阶段：${stageLabel}。${description}`;
+	}
+
+	function getDanmakuLastSyncedTitle(value?: string | null) {
+		return value ? '显示最近一次成功刷新弹幕的北京时间。' : '当前还没有记录过弹幕刷新时间。';
+	}
+
+	function getRefreshVideoDanmakuTitle() {
+		return '手动刷新当前视频全部分页的弹幕。已存在的弹幕文件会按日期增量追加。';
+	}
+
+	function getRefreshPageDanmakuTitle(path?: string | null) {
+		return path
+			? '手动刷新当前分页的弹幕。已存在的弹幕文件会按日期增量追加。'
+			: '当前分页还没有本地文件路径，暂时无法刷新弹幕。';
+	}
+
+	function getRelativeDanmakuTime(value?: string | null) {
+		const date = parseBeijingTimestamp(value);
+		if (!date) return '未同步';
+		const diffSeconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+		if (diffSeconds < 60) return '刚刚';
+		if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)} 分钟前`;
+		if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)} 小时前`;
+		if (diffSeconds < 86400 * 7) return `${Math.floor(diffSeconds / 86400)} 天前`;
+		return value ?? '未同步';
+	}
+
+	function formatDanmakuWriteCount(count?: number | null) {
+		return `${Math.max(0, count ?? 0)} 条`;
+	}
+
+	function isRefreshingPage(pageId: number) {
+		return refreshingPageIds.has(pageId);
+	}
+
+	async function handleRefreshVideoDanmaku() {
+		if (!videoData) return;
+
+		refreshingVideoDanmaku = true;
+		try {
+			const result = await api.refreshVideoDanmaku(videoData.video.id);
+			toast.success('弹幕刷新完成', {
+				description: result.data.message
+			});
+			await loadVideoDetail();
+		} catch (error) {
+			console.error('刷新整条视频弹幕失败:', error);
+			toast.error('刷新弹幕失败', {
+				description: (error as ApiError).message
+			});
+		} finally {
+			refreshingVideoDanmaku = false;
+		}
+	}
+
+	async function handleRefreshPageDanmaku(pageId: number) {
+		refreshingPageIds = new Set(refreshingPageIds).add(pageId);
+		try {
+			const result = await api.refreshPageDanmaku(pageId);
+			toast.success('分页弹幕刷新完成', {
+				description: result.data.message
+			});
+			await loadVideoDetail();
+		} catch (error) {
+			console.error('刷新分页弹幕失败:', error);
+			toast.error('刷新分页弹幕失败', {
+				description: (error as ApiError).message
+			});
+		} finally {
+			const next = new Set(refreshingPageIds);
+			next.delete(pageId);
+			refreshingPageIds = next;
 		}
 	}
 
@@ -249,7 +370,6 @@
 				await findAndLoadPageForVideo(videoId);
 				if (loadToken !== videoDetailLoadToken) return;
 			}
-
 		} catch (error) {
 			if (loadToken !== videoDetailLoadToken) return;
 			console.error('加载视频详情失败:', error);
@@ -628,8 +748,23 @@
 		{#if videoData.pages && videoData.pages.length > 0}
 			<div class="mb-4 flex {isMobile ? 'flex-col gap-2' : 'items-center justify-between'}">
 				<h2 class="{isMobile ? 'text-lg' : 'text-xl'} font-semibold">分页列表</h2>
-				<div class="text-muted-foreground text-sm">
-					共 {videoData.pages.length} 个分页
+				<div class="flex {isMobile ? 'flex-col gap-2' : 'items-center gap-2'}">
+					<div class="text-muted-foreground text-sm">
+						共 {videoData.pages.length} 个分页
+					</div>
+					<Button
+						size="sm"
+						variant="outline"
+						class={isMobile ? 'w-full' : ''}
+						title={getRefreshVideoDanmakuTitle()}
+						onclick={handleRefreshVideoDanmaku}
+						disabled={refreshingVideoDanmaku}
+					>
+						<RefreshCwIcon
+							class="mr-2 h-4 w-4 {refreshingVideoDanmaku ? 'animate-spin' : ''}"
+						/>
+						{refreshingVideoDanmaku ? '刷新中...' : '刷新全部弹幕'}
+					</Button>
 				</div>
 			</div>
 
@@ -663,24 +798,81 @@
 									customTitle="P{pageInfo.pid}: {pageInfo.name}"
 									customSubtitle=""
 									taskNames={['视频封面', '视频内容', '视频信息', '视频弹幕', '视频字幕']}
-									showProgress={false}
+									showProgress={true}
 								/>
+
+								<div class="bg-muted/40 flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+									<div class="min-w-0">
+										<div
+											class="text-muted-foreground cursor-help text-xs"
+											title={getDanmakuSyncTitle(
+												pageInfo.danmaku_sync_generation,
+												pageInfo.danmaku_last_synced_at
+											)}
+										>
+											弹幕同步
+										</div>
+										<div
+											class="truncate cursor-help text-sm font-medium"
+											title={getDanmakuSyncTitle(
+												pageInfo.danmaku_sync_generation,
+												pageInfo.danmaku_last_synced_at
+											)}
+										>
+											{getDanmakuStageLabel(pageInfo.danmaku_sync_generation)}
+											{#if pageInfo.danmaku_last_synced_at}
+												· {getRelativeDanmakuTime(pageInfo.danmaku_last_synced_at)}
+											{:else}
+												· 未同步
+											{/if}
+										</div>
+										{#if pageInfo.danmaku_last_synced_at}
+											<div
+												class="text-muted-foreground cursor-help text-[11px]"
+												title={getDanmakuLastSyncedTitle(pageInfo.danmaku_last_synced_at)}
+											>
+												上次刷新：{pageInfo.danmaku_last_synced_at}
+											</div>
+											<div class="text-muted-foreground flex items-center gap-1 text-[11px]">
+												<span
+													class="cursor-help"
+													title="显示最近一次写入到弹幕文件的条数。首次刷新通常是全量写入，之后会按日期增量追加。"
+												>
+													上次写入：{formatDanmakuWriteCount(pageInfo.danmaku_last_write_count)}
+												</span>
+											</div>
+										{/if}
+									</div>
+									<Button
+										size="sm"
+										variant="outline"
+										class="shrink-0"
+										title={getRefreshPageDanmakuTitle(pageInfo.path)}
+										onclick={() => handleRefreshPageDanmaku(pageInfo.id)}
+										disabled={isRefreshingPage(pageInfo.id) || !pageInfo.path}
+									>
+										<RefreshCwIcon
+											class="mr-2 h-4 w-4 {isRefreshingPage(pageInfo.id) ? 'animate-spin' : ''}"
+										/>
+										{isRefreshingPage(pageInfo.id) ? '刷新中...' : '刷新弹幕'}
+									</Button>
+								</div>
 
 								<!-- 播放按钮区域 -->
 								<div class="flex justify-center gap-2">
 									{#if pageInfo.download_status[1] === 7}
-									<Button
-										size="sm"
-										variant="default"
-										class="flex-1"
-										title="本地播放"
-										onclick={() => {
-											currentPlayingPageIndex = index;
-											onlinePlayMode = false;
-											chargeLockedDisplayMode = null;
-											showVideoPlayer = true;
-										}}
-									>
+										<Button
+											size="sm"
+											variant="default"
+											class="flex-1"
+											title="本地播放"
+											onclick={() => {
+												currentPlayingPageIndex = index;
+												onlinePlayMode = false;
+												chargeLockedDisplayMode = null;
+												showVideoPlayer = true;
+											}}
+										>
 											<PlayIcon class="mr-2 h-4 w-4" />
 											本地播放
 										</Button>
@@ -700,31 +892,6 @@
 										<PlayIcon class="mr-2 h-4 w-4" />
 										B站内嵌
 									</Button>
-								</div>
-
-								<!-- 下载进度条 -->
-								<div class="space-y-2 px-1">
-									<div class="text-muted-foreground flex justify-between text-xs">
-										<span class="truncate">下载进度</span>
-										<span class="shrink-0"
-											>{pageInfo.download_status.filter((s) => s === 7).length}/{pageInfo
-												.download_status.length}</span
-										>
-									</div>
-									<div class="flex w-full gap-1">
-										{#each pageInfo.download_status as status, taskIndex (taskIndex)}
-											<div
-												class="h-2 w-full cursor-help rounded-sm transition-all {status === 7
-													? 'bg-green-500'
-													: status === 0
-														? 'bg-yellow-500'
-														: 'bg-red-500'}"
-												title="{['视频封面', '视频内容', '视频信息', '视频弹幕', '视频字幕'][
-													taskIndex
-												]}: {status === 7 ? '已完成' : status === 0 ? '未开始' : `失败${status}次`}"
-											></div>
-										{/each}
-									</div>
 								</div>
 							</div>
 						{/each}
@@ -767,7 +934,8 @@
 							{/if}
 							{#if onlinePlayMode}
 								<div class="mb-3 text-sm text-gray-500">
-									当前为 B 站内嵌播放，清晰度和码率由 B 站播放器控制，不继承 bili-sync 的清晰度设置。
+									当前为 B 站内嵌播放，清晰度和码率由 B 站播放器控制，不继承 bili-sync
+									的清晰度设置。
 								</div>
 							{/if}
 
@@ -802,11 +970,11 @@
 												class="h-auto w-full"
 												style="aspect-ratio: 16/9; max-height: 70vh;"
 												src={getVideoSource()}
-											onerror={(event) => {
-												console.warn('视频加载错误:', event);
-												if (videoData?.video.is_charge_video) {
-													chargeLockedDisplayMode = 'local';
-													showChargeLockedToast('local');
+												onerror={(event) => {
+													console.warn('视频加载错误:', event);
+													if (videoData?.video.is_charge_video) {
+														chargeLockedDisplayMode = 'local';
+														showChargeLockedToast('local');
 													}
 												}}
 												onloadstart={() => {


### PR DESCRIPTION
## Summary
- 手工 backport 弹幕增量更新能力，新增分页级同步策略、手动刷新接口与状态字段
- 将弹幕文件刷新改为按日期增量追加，保留首次全量生成与 cid 变化时的全量重建
- 在设置页和视频详情页补充弹幕同步状态、刷新入口与悬浮说明，并把分页下载进度移回卡片内部

## Validation
- cargo test --bin bili-sync-rs event_name_roundtrip
- cargo test --bin bili-sync-rs parse_existing_danmaku_cursor_collects_metadata
- cargo test --bin bili-sync-rs filter_incremental_danmaku_uses_cutoff_and_dedup
- cd web && npx -y -p node@20 -c "node --version && npm run build"
- cargo build

## Notes
- danmaku_last_write_count 已合并进 m20260414_000001_add_danmaku_sync_fields，并在启动时补列兼容已跑过旧迁移的本地库
- 当前抓取层仍沿用 x/v2/dm/web/seg.so 分段接口，先聚焦调度增量与文件追加，暂未引入分段并发抓取