### PR TITLE
继续完善前端UI复用

### DIFF
--- a/web/FRONTEND_REUSE_NOTES.md
+++ b/web/FRONTEND_REUSE_NOTES.md
@@ -1,0 +1,178 @@
+# 前端可复用/可合并项检查记录
+
+检查时间：2026-04-16
+范围：`web/src/routes`、`web/src/lib/components`、`web/src/lib/utils`
+
+## 本次已落地的复用改造
+
+### 1. 认证型 SSE/live 地址构建逻辑已收敛
+
+原本以下页面都各自做了一遍：
+
+- 从 `localStorage` 读取 `auth_token`
+- 拼接 `URLSearchParams`
+- 生成 `/api/*/live?...&token=...`
+
+涉及页面：
+
+- `web/src/routes/videos/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/queue/+page.svelte`
+
+本次新增：
+
+- `web/src/lib/utils/live-stream.ts`
+  - `buildAuthenticatedStreamUrl(path, params)`
+
+收益：
+
+- 避免 3 处重复实现
+- 统一 token 缺失时的返回行为
+- 后续如果 live 接口追加公共参数，只需要改一个地方
+
+### 2. 时间格式化失败兜底逻辑已收敛
+
+原本多处都重复做：
+
+- `formatTimestamp(...)`
+- 判断是否为 `无效时间` / `格式化失败`
+- 回退到原始值或默认值
+
+本次已收敛到：
+
+- `web/src/lib/utils/timezone.ts`
+  - `isInvalidFormattedTime(value)`
+  - `formatTimestampOrFallback(timestamp, timezone, format, fallback)`
+
+已替换位置：
+
+- `web/src/routes/+layout.svelte`
+- `web/src/routes/+page.svelte`
+- `web/src/routes/add-source/+page.svelte`
+- `web/src/routes/queue/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/lib/components/submission-selection-dialog.svelte`
+
+收益：
+
+- 去掉重复的无效时间判断
+- 保持页面展示行为一致
+- 后续时间格式化策略调整时只改一个公共入口
+
+### 3. SSE 生命周期管理做了第二轮收敛
+
+原本以下页面都各自维护：
+
+- `EventSource` 实例
+- 当前 stream url
+- `stop()` 关闭逻辑
+- `start()` 中的“同 URL 不重复连接”逻辑
+- `onerror` 仅对当前连接生效的保护
+
+涉及页面：
+
+- `web/src/routes/videos/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/queue/+page.svelte`
+
+本次新增：
+
+- `web/src/lib/utils/live-event-source.ts`
+  - `createManagedEventSource()`
+
+本次改造后：
+
+- 页面只保留自己的业务事件处理
+- 通用连接管理下沉到公共 helper
+- `videos` 页面仍保留自己的 `liveUpdateStatus` 业务状态控制
+
+收益：
+
+- 去掉重复的 EventSource 管理样板代码
+- 降低三页后续各自改坏连接逻辑的风险
+- 为后续更多 live 页面接入提供统一模式
+
+### 4. 投稿列表展示 helper 与选择工具栏完成第三轮收敛
+
+原本投稿列表相关 UI 在两个位置各自维护：
+
+- 日期展示格式化
+- 播放/弹幕等数值展示格式化
+- 搜索输入框 + 搜索中 spinner
+- 全选 / 全不选 / 反选按钮组
+- 已选择数量统计
+
+涉及位置：
+
+- `web/src/routes/add-source/+page.svelte`
+- `web/src/lib/components/submission-selection-dialog.svelte`
+
+本次新增：
+
+- `web/src/lib/utils/submission.ts`
+  - `formatSubmissionDateLabel(pubtime)`
+  - `formatSubmissionMetricLabel(count)`
+- `web/src/lib/components/submission-selection-toolbar.svelte`
+
+本次改造后：
+
+- 投稿日期与数值展示统一由公共 helper 负责
+- 投稿选择区搜索与批量选择操作统一到公共组件
+- `add-source` 与投稿选择弹窗共享同一套工具栏实现
+
+收益：
+
+- 去掉重复的投稿日期/数值格式化函数
+- 去掉重复的“搜索 + 批量选择”工具栏样板代码
+- 后续如果修改投稿选择交互，只需要改一个组件
+
+### 5. 页面级标题/操作区已统一到 SectionHeader
+
+本次已将以下页面头部切换到统一组件：
+
+- `web/src/routes/videos/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/queue/+page.svelte`
+- `web/src/routes/add-source/+page.svelte`
+
+收益：
+
+- 页面标题、描述和操作按钮布局风格统一
+- 后续新增页面头部时可直接复用 `SectionHeader`
+- 减少页面级重复布局代码
+
+## 当前检查范围内的复用项已完成
+
+本轮记录中的剩余项已经全部落地处理：
+
+- 投稿日期展示 helper：已完成
+- 页面级标题/操作区统一：已完成
+- 重复搜索区/批量选择工具栏统一：已完成
+
+## 本次修改文件
+
+- `web/src/lib/utils/timezone.ts`
+- `web/src/lib/utils/live-stream.ts`
+- `web/src/lib/utils/live-event-source.ts`
+- `web/src/lib/utils/submission.ts`
+- `web/src/lib/components/submission-selection-toolbar.svelte`
+- `web/src/routes/+layout.svelte`
+- `web/src/routes/+page.svelte`
+- `web/src/routes/add-source/+page.svelte`
+- `web/src/routes/queue/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/videos/+page.svelte`
+- `web/src/lib/components/submission-selection-dialog.svelte`
+
+## 结论
+
+本次按三轮完成了前端可复用项收敛：
+
+1. 认证型 SSE/live URL 构建统一
+2. 时间格式化失败兜底统一
+3. SSE 生命周期管理统一
+4. 投稿列表日期/数值展示 helper 统一
+5. 投稿选择搜索与批量操作工具栏统一
+6. 页面级标题/操作区统一到 `SectionHeader`
+
+当前检查范围内识别出的前端复用点已经全部落地完成，并已通过 Node 20 的 `check` / `build` 验证。

--- a/web/FRONTEND_REUSE_NOTES.md
+++ b/web/FRONTEND_REUSE_NOTES.md
@@ -141,6 +141,75 @@
 - 后续新增页面头部时可直接复用 `SectionHeader`
 - 减少页面级重复布局代码
 
+### 6. 页面级加载态样式统一为 Loading 组件
+
+原本多个页面都各自写一段相同的：
+
+- `flex items-center justify-center py-*`
+- `text-muted-foreground`
+- `加载中...`
+
+涉及页面：
+
+- `web/src/routes/+page.svelte`
+- `web/src/routes/settings/+page.svelte`
+- `web/src/routes/video/[id]/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/videos/+page.svelte`
+
+本次新增/复用：
+
+- `web/src/lib/components/ui/Loading.svelte`
+
+本次改造后：
+
+- 页面级通用加载态统一使用 `<Loading />`
+- 支持 `size` 参数，兼容不同页面的垂直间距
+
+收益：
+
+- 去掉重复加载态样板代码
+- 页面级 loading 样式统一
+- 后续若要替换成 spinner / skeleton，可集中在一个组件里演进
+
+### 7. 批量选择按钮与局部 loading 交互进一步统一
+
+原本多个面板和弹窗中还存在重复的 UI 片段：
+
+- `全选` 小按钮
+- 带 spinner 的局部 `加载中...`
+- 加载更多按钮中的白色 spinner + 文案
+
+涉及位置：
+
+- `web/src/routes/add-source/+page.svelte`
+- `web/src/routes/video-sources/+page.svelte`
+- `web/src/routes/videos/+page.svelte`
+- `web/src/lib/components/submission-selection-dialog.svelte`
+- `web/src/lib/components/submission-selection-toolbar.svelte`
+- `web/src/lib/components/keyword-filter-dialog.svelte`
+
+本次新增/增强：
+
+- `web/src/lib/components/select-all-button.svelte`
+- 增强 `web/src/lib/components/ui/Loading.svelte`
+  - 支持 `inline`
+  - 支持 `showSpinner`
+  - 支持 `align`
+  - 支持 `spinnerClass` / `textClass`
+
+本次改造后：
+
+- 多处 `全选` 按钮统一为公共组件
+- 多处局部 spinner loading 统一由 `Loading` 组件承担
+- 加载更多按钮中的 loading 内容也统一复用
+
+收益：
+
+- 减少重复按钮样式与局部 loading 样板代码
+- 小型交互反馈风格更统一
+- 后续修改局部 loading / 全选按钮样式时只需改公共组件
+
 ## 当前检查范围内的复用项已完成
 
 本轮记录中的剩余项已经全部落地处理：
@@ -156,12 +225,17 @@
 - `web/src/lib/utils/live-event-source.ts`
 - `web/src/lib/utils/submission.ts`
 - `web/src/lib/components/submission-selection-toolbar.svelte`
+- `web/src/lib/components/select-all-button.svelte`
+- `web/src/lib/components/ui/Loading.svelte`
+- `web/src/lib/components/keyword-filter-dialog.svelte`
 - `web/src/routes/+layout.svelte`
 - `web/src/routes/+page.svelte`
 - `web/src/routes/add-source/+page.svelte`
 - `web/src/routes/queue/+page.svelte`
 - `web/src/routes/video-sources/+page.svelte`
 - `web/src/routes/videos/+page.svelte`
+- `web/src/routes/video/[id]/+page.svelte`
+- `web/src/routes/settings/+page.svelte`
 - `web/src/lib/components/submission-selection-dialog.svelte`
 
 ## 结论
@@ -174,5 +248,7 @@
 4. 投稿列表日期/数值展示 helper 统一
 5. 投稿选择搜索与批量操作工具栏统一
 6. 页面级标题/操作区统一到 `SectionHeader`
+7. 页面级通用加载态统一到 `Loading`
+8. 批量选择按钮与局部 spinner loading 统一
 
 当前检查范围内识别出的前端复用点已经全部落地完成，并已通过 Node 20 的 `check` / `build` 验证。

--- a/web/package.json
+++ b/web/package.json
@@ -8,14 +8,18 @@
 		"dev": "vite dev",
 		"prebuild": "node scripts/generate-app-meta.mjs",
 		"build": "vite build",
+		"build:node20": "npx -y -p node@20 -c \"node --version && npm run build\"",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"precheck": "node scripts/generate-app-meta.mjs",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check:node20": "npx -y -p node@20 -c \"node --version && npm run check\"",
 		"precheck:watch": "node scripts/generate-app-meta.mjs",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
+		"lint": "prettier --check . && eslint .",
+		"validate:changed": "node scripts/validate-changed.mjs",
+		"validate:node20": "npx -y -p node@20 -c \"node --version && npm run check && npm run build && npm run validate:changed\""
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",

--- a/web/scripts/validate-changed.mjs
+++ b/web/scripts/validate-changed.mjs
@@ -1,0 +1,67 @@
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const webRoot = process.cwd();
+const repoRoot = path.resolve(webRoot, '..');
+
+function run(command, options = {}) {
+	console.log(`\n$ ${command}`);
+	execSync(command, {
+		cwd: options.cwd ?? webRoot,
+		stdio: 'inherit',
+		env: process.env,
+		shell: true
+	});
+}
+
+function collectChangedFiles() {
+	const output = execSync('git status --porcelain', {
+		cwd: repoRoot,
+		encoding: 'utf8'
+	});
+
+	return output
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.map((line) => line.slice(3).trim())
+		.filter((file) => file.startsWith('web/'))
+		.map((file) => file.replace(/^web\//, ''))
+		.filter((file) => existsSync(path.join(webRoot, file)));
+}
+
+function shellQuote(file) {
+	return JSON.stringify(file);
+}
+
+const changedFiles = collectChangedFiles();
+if (changedFiles.length === 0) {
+	console.log('No changed files under web/. Skipping changed-file validation.');
+	process.exit(0);
+}
+
+console.log('Changed files under web/:');
+for (const file of changedFiles) {
+	console.log(`- ${file}`);
+}
+
+const prettierTargets = changedFiles.filter((file) =>
+	/\.(svelte|ts|js|mjs|json|md|css)$/i.test(file)
+);
+const eslintTargets = changedFiles.filter((file) => /\.(svelte|ts|js|mjs)$/i.test(file));
+
+if (prettierTargets.length > 0) {
+	run(
+		`node ./node_modules/prettier/bin/prettier.cjs --check ${prettierTargets.map(shellQuote).join(' ')}`,
+		{ cwd: webRoot }
+	);
+}
+
+if (eslintTargets.length > 0) {
+	run(`node ./node_modules/eslint/bin/eslint.js ${eslintTargets.map(shellQuote).join(' ')}`, {
+		cwd: webRoot
+	});
+}
+
+console.log('\nChanged-file validation passed.');

--- a/web/src/lib/components/keyword-filter-dialog.svelte
+++ b/web/src/lib/components/keyword-filter-dialog.svelte
@@ -2,6 +2,7 @@
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { createEventDispatcher } from 'svelte';
 	import { api } from '$lib/api';
+	import Loading from '$lib/components/ui/Loading.svelte';
 
 	export let isOpen = false;
 	export let sourceName = '';
@@ -426,7 +427,7 @@
 								bind:value={minDurationSeconds}
 								disabled={isSaving}
 								placeholder="例如 60"
-								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
+								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm transition outline-none focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
 							/>
 						</div>
 						<div class="space-y-1">
@@ -442,7 +443,7 @@
 								bind:value={maxDurationSeconds}
 								disabled={isSaving}
 								placeholder="例如 1800"
-								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
+								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm transition outline-none focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
 							/>
 						</div>
 						<div class="space-y-1">
@@ -455,7 +456,7 @@
 								type="date"
 								bind:value={publishedAfter}
 								disabled={isSaving}
-								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
+								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm transition outline-none focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
 							/>
 						</div>
 						<div class="space-y-1">
@@ -468,7 +469,7 @@
 								type="date"
 								bind:value={publishedBefore}
 								disabled={isSaving}
-								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none transition focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
+								class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm transition outline-none focus:border-amber-500 dark:border-gray-600 dark:bg-gray-900"
 							/>
 						</div>
 					</div>
@@ -481,24 +482,12 @@
 				</div>
 
 				{#if isLoading}
-					<div class="flex items-center justify-center py-8">
-						<svg class="h-6 w-6 animate-spin text-purple-600" fill="none" viewBox="0 0 24 24">
-							<circle
-								class="opacity-25"
-								cx="12"
-								cy="12"
-								r="10"
-								stroke="currentColor"
-								stroke-width="4"
-							></circle>
-							<path
-								class="opacity-75"
-								fill="currentColor"
-								d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-							></path>
-						</svg>
-						<span class="ml-2 text-sm text-gray-500">加载中...</span>
-					</div>
+					<Loading
+						showSpinner={true}
+						spinnerClass="text-purple-600"
+						textClass="text-sm text-gray-500"
+						class="py-8"
+					/>
 				{:else}
 					<!-- 标签页切换 -->
 					<div class="flex border-b border-gray-200 dark:border-gray-700">

--- a/web/src/lib/components/select-all-button.svelte
+++ b/web/src/lib/components/select-all-button.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+
+	export let onclick: (() => void) | undefined = undefined;
+	export let disabled = false;
+	export let label = '全选';
+	export let className = 'text-xs';
+</script>
+
+<Button size="sm" variant="outline" {disabled} {onclick} class={className}>
+	{label}
+</Button>

--- a/web/src/lib/components/submission-selection-dialog.svelte
+++ b/web/src/lib/components/submission-selection-dialog.svelte
@@ -7,7 +7,8 @@
 	import api from '$lib/api';
 	import type { SubmissionVideoInfo } from '$lib/types';
 	import { toast } from 'svelte-sonner';
-	import { formatTimestamp } from '$lib/utils/timezone';
+	import SubmissionSelectionToolbar from '$lib/components/submission-selection-toolbar.svelte';
+	import { formatSubmissionDateLabel, formatSubmissionMetricLabel } from '$lib/utils/submission';
 
 	export let isOpen = false;
 	export let sourceId: number;
@@ -53,23 +54,6 @@
 	// 已选中视频数量
 	$: selectedSubmissionCount = selectedSubmissionVideos.size;
 
-	// 格式化时间
-	function formatSubmissionDate(pubtime: string): string {
-		const formatted = formatTimestamp(pubtime, 'Asia/Shanghai', 'date');
-		if (formatted === '无效时间' || formatted === '格式化失败') {
-			return pubtime;
-		}
-		return formatted;
-	}
-
-	// 格式化播放量
-	function formatSubmissionPlayCount(count: number): string {
-		if (count >= 10000) {
-			return (count / 10000).toFixed(1) + '万';
-		}
-		return count.toString();
-	}
-
 	// 当对话框打开时加载数据
 	$: if (isOpen && upperId) {
 		resetAndLoad();
@@ -93,7 +77,6 @@
 		// 并行加载已下载视频和UP主投稿
 		await Promise.all([loadDownloadedVideos(), loadSubmissionVideos()]);
 		updateFilteredVideos();
-
 	}
 
 	// 加载该投稿源已下载的视频BVID列表
@@ -183,14 +166,13 @@
 		hasMoreVideos = submissionVideos.length < submissionTotalCount;
 		loadingProgress = '';
 		updateFilteredVideos();
-
 	}
 
 	// 更新过滤后的视频列表（排除已下载的）
 
 	function updateFilteredVideos() {
 		const baseVideos = submissionSearchQuery.trim()
-			? searchedSubmissionVideos ?? []
+			? (searchedSubmissionVideos ?? [])
 			: submissionVideos;
 		filteredSubmissionVideos = baseVideos.filter((video) => !downloadedBvids.has(video.bvid));
 
@@ -404,79 +386,23 @@
 				</div>
 			{:else}
 				<!-- 搜索和操作栏 -->
-				<div class="flex-shrink-0 space-y-2 px-1 sm:space-y-3">
-					<div class="flex gap-2">
-						<div class="relative flex-1">
-							<input
-								type="text"
-								bind:value={submissionSearchQuery}
-								placeholder="搜索视频标题..."
-								class="w-full rounded-md border border-gray-300 px-2 py-1.5 pr-8 text-xs focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none sm:px-3 sm:py-2 sm:text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-								disabled={isSearching}
-							/>
-							{#if isSearching}
-								<div class="absolute inset-y-0 right-0 flex items-center pr-3">
-									<svg class="h-4 w-4 animate-spin text-blue-600" fill="none" viewBox="0 0 24 24">
-										<circle
-											class="opacity-25"
-											cx="12"
-											cy="12"
-											r="10"
-											stroke="currentColor"
-											stroke-width="4"
-										></circle>
-										<path
-											class="opacity-75"
-											fill="currentColor"
-											d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-										></path>
-									</svg>
-								</div>
-							{/if}
-						</div>
-					</div>
-
-					{#if submissionSearchQuery.trim()}
-						<div class="px-1 text-xs text-blue-600">
-							{isSearching
-								? '搜索中...'
-								: `搜索结果：在UP主所有视频中搜索 "${submissionSearchQuery}"`}
-						</div>
-					{/if}
-
-					<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-						<div class="flex gap-1 sm:gap-2">
-							<button
-								type="button"
-								class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-2 py-1 text-xs font-medium sm:px-3 sm:text-sm dark:border-gray-600"
-								onclick={selectAllSubmissions}
-								disabled={filteredSubmissionVideos.length === 0}
-							>
-								全选
-							</button>
-							<button
-								type="button"
-								class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-2 py-1 text-xs font-medium sm:px-3 sm:text-sm dark:border-gray-600"
-								onclick={selectNoneSubmissions}
-								disabled={selectedSubmissionCount === 0}
-							>
-								全不选
-							</button>
-							<button
-								type="button"
-								class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-2 py-1 text-xs font-medium sm:px-3 sm:text-sm dark:border-gray-600"
-								onclick={invertSubmissionSelection}
-								disabled={filteredSubmissionVideos.length === 0}
-							>
-								反选
-							</button>
-						</div>
-
-						<div class="text-muted-foreground text-xs sm:text-sm">
-							已选择 {selectedSubmissionCount} / {filteredSubmissionVideos.length} 个视频
-						</div>
-					</div>
-				</div>
+				<SubmissionSelectionToolbar
+					bind:query={submissionSearchQuery}
+					compact={true}
+					placeholder="搜索视频标题..."
+					{isSearching}
+					statusText={isSearching
+						? '搜索中...'
+						: `搜索结果：在UP主所有视频中搜索 \"${submissionSearchQuery}\"`}
+					selectedCount={selectedSubmissionCount}
+					totalCount={filteredSubmissionVideos.length}
+					onSelectAll={selectAllSubmissions}
+					onSelectNone={selectNoneSubmissions}
+					onInvert={invertSubmissionSelection}
+					selectAllDisabled={filteredSubmissionVideos.length === 0}
+					selectNoneDisabled={selectedSubmissionCount === 0}
+					invertDisabled={filteredSubmissionVideos.length === 0}
+				/>
 
 				<!-- 视频列表 -->
 				<div
@@ -588,9 +514,9 @@
 											{video.title}
 										</h4>
 										<div class="text-muted-foreground mt-1 flex items-center gap-1 text-[10px]">
-											<span>{formatSubmissionPlayCount(video.view)}播放</span>
+											<span>{formatSubmissionMetricLabel(video.view)}播放</span>
 											<span>·</span>
-											<span>{formatSubmissionDate(video.pubtime)}</span>
+											<span>{formatSubmissionDateLabel(video.pubtime)}</span>
 										</div>
 									</div>
 								</div>

--- a/web/src/lib/components/submission-selection-dialog.svelte
+++ b/web/src/lib/components/submission-selection-dialog.svelte
@@ -8,6 +8,7 @@
 	import type { SubmissionVideoInfo } from '$lib/types';
 	import { toast } from 'svelte-sonner';
 	import SubmissionSelectionToolbar from '$lib/components/submission-selection-toolbar.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
 	import { formatSubmissionDateLabel, formatSubmissionMetricLabel } from '$lib/utils/submission';
 
 	export let isOpen = false;
@@ -411,28 +412,12 @@
 					onscroll={handleSubmissionScroll}
 				>
 					{#if (submissionLoading || loadingDownloaded) && submissionVideos.length === 0}
-						<div class="flex items-center justify-center py-8">
-							<svg
-								class="h-8 w-8 animate-spin text-blue-600 dark:text-blue-400"
-								fill="none"
-								viewBox="0 0 24 24"
-							>
-								<circle
-									class="opacity-25"
-									cx="12"
-									cy="12"
-									r="10"
-									stroke="currentColor"
-									stroke-width="4"
-								></circle>
-								<path
-									class="opacity-75"
-									fill="currentColor"
-									d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-								></path>
-							</svg>
-							<span class="text-muted-foreground ml-2 text-sm">加载中...</span>
-						</div>
+						<Loading
+							showSpinner={true}
+							spinnerClass="text-blue-600 dark:text-blue-400"
+							textClass="text-sm"
+							class="py-8"
+						/>
 					{:else if filteredSubmissionVideos.length === 0}
 						<div class="text-muted-foreground flex flex-col items-center justify-center py-8">
 							<svg class="mb-2 h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -462,12 +447,13 @@
 									disabled={isLoadingMore}
 								>
 									{#if isLoadingMore}
-										<div class="flex items-center gap-2">
-											<div
-												class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-											></div>
-											<span>加载中...</span>
-										</div>
+										<Loading
+											inline={true}
+											showSpinner={true}
+											spinnerClass="text-white"
+											textClass="text-white"
+											class="gap-2"
+										/>
 									{:else}
 										加载更多历史投稿 ({submissionVideos.length}/{submissionTotalCount})
 									{/if}
@@ -533,12 +519,13 @@
 										disabled={isLoadingMore}
 									>
 										{#if isLoadingMore}
-											<div class="flex items-center gap-2">
-												<div
-													class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-												></div>
-												<span>加载中...</span>
-											</div>
+											<Loading
+												inline={true}
+												showSpinner={true}
+												spinnerClass="text-white"
+												textClass="text-white"
+												class="gap-2"
+											/>
 										{:else}
 											加载更多 ({submissionVideos.length}/{submissionTotalCount})
 										{/if}

--- a/web/src/lib/components/submission-selection-toolbar.svelte
+++ b/web/src/lib/components/submission-selection-toolbar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import SelectAllButton from '$lib/components/select-all-button.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
 	import { Button } from '$lib/components/ui/button';
 
 	export let query = '';
@@ -49,17 +51,13 @@
 				disabled={isSearching}
 			/>
 			{#if isSearching}
-				<div class="absolute inset-y-0 right-0 flex items-center pr-3">
-					<svg class="h-4 w-4 animate-spin text-blue-600" fill="none" viewBox="0 0 24 24">
-						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
-						></circle>
-						<path
-							class="opacity-75"
-							fill="currentColor"
-							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-						></path>
-					</svg>
-				</div>
+				<Loading
+					inline={true}
+					showSpinner={true}
+					spinnerClass="text-blue-600"
+					text=""
+					class="absolute inset-y-0 right-0 pr-3"
+				/>
 			{/if}
 		</div>
 	</div>
@@ -70,13 +68,11 @@
 
 	<div class={controlsClass}>
 		<div class={actionGroupClass}>
-			<Button
-				type="button"
-				variant="ghost"
-				class={buttonClass}
+			<SelectAllButton
 				onclick={onSelectAll}
-				disabled={selectAllDisabled}>全选</Button
-			>
+				disabled={selectAllDisabled}
+				className={compact ? 'text-xs' : 'text-sm'}
+			/>
 			<Button
 				type="button"
 				variant="ghost"

--- a/web/src/lib/components/submission-selection-toolbar.svelte
+++ b/web/src/lib/components/submission-selection-toolbar.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+
+	export let query = '';
+	export let placeholder = '搜索视频标题...';
+	export let isSearching = false;
+	export let statusText = '';
+	export let compact = false;
+	export let selectedCount = 0;
+	export let totalCount = 0;
+	export let onSelectAll: (() => void) | undefined = undefined;
+	export let onSelectNone: (() => void) | undefined = undefined;
+	export let onInvert: (() => void) | undefined = undefined;
+	export let selectAllDisabled = false;
+	export let selectNoneDisabled = false;
+	export let invertDisabled = false;
+
+	const inputClassBase =
+		'w-full rounded-md border border-gray-300 pr-8 focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none dark:border-gray-600 dark:bg-gray-700 dark:text-white';
+	const buttonClassBase =
+		'bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 font-medium dark:border-gray-600';
+
+	$: inputClass = compact
+		? `${inputClassBase} px-2 py-1.5 text-xs sm:px-3 sm:py-2 sm:text-sm`
+		: `${inputClassBase} px-3 py-2 text-sm`;
+	$: buttonClass = compact
+		? `${buttonClassBase} px-2 py-1 text-xs sm:px-3 sm:text-sm`
+		: `${buttonClassBase} px-3 py-1 text-sm`;
+	$: wrapperClass = compact
+		? 'flex-shrink-0 space-y-2 px-1 sm:space-y-3'
+		: 'flex-shrink-0 space-y-3 p-3';
+	$: summaryClass = compact
+		? 'text-muted-foreground text-xs sm:text-sm'
+		: 'text-muted-foreground text-sm';
+	$: controlsClass = compact
+		? 'flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'
+		: 'flex items-center justify-between';
+	$: actionGroupClass = compact ? 'flex gap-1 sm:gap-2' : 'flex gap-2';
+</script>
+
+<div class={wrapperClass}>
+	<div class="flex gap-2">
+		<div class="relative flex-1">
+			<input
+				type="text"
+				bind:value={query}
+				{placeholder}
+				class={inputClass}
+				disabled={isSearching}
+			/>
+			{#if isSearching}
+				<div class="absolute inset-y-0 right-0 flex items-center pr-3">
+					<svg class="h-4 w-4 animate-spin text-blue-600" fill="none" viewBox="0 0 24 24">
+						<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+						></circle>
+						<path
+							class="opacity-75"
+							fill="currentColor"
+							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+						></path>
+					</svg>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	{#if query.trim() && statusText}
+		<div class="px-1 text-xs text-blue-600">{statusText}</div>
+	{/if}
+
+	<div class={controlsClass}>
+		<div class={actionGroupClass}>
+			<Button
+				type="button"
+				variant="ghost"
+				class={buttonClass}
+				onclick={onSelectAll}
+				disabled={selectAllDisabled}>全选</Button
+			>
+			<Button
+				type="button"
+				variant="ghost"
+				class={buttonClass}
+				onclick={onSelectNone}
+				disabled={selectNoneDisabled}>全不选</Button
+			>
+			<Button
+				type="button"
+				variant="ghost"
+				class={buttonClass}
+				onclick={onInvert}
+				disabled={invertDisabled}>反选</Button
+			>
+		</div>
+
+		<div class={summaryClass}>已选择 {selectedCount} / {totalCount} 个视频</div>
+	</div>
+</div>

--- a/web/src/lib/components/ui/Loading.svelte
+++ b/web/src/lib/components/ui/Loading.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	let {
+		text = '加载中...',
+		size = 'default',
+		inline = false,
+		showSpinner = false,
+		align = 'center',
+		spinnerClass = '',
+		textClass = '',
+		class: className = ''
+	}: {
+		text?: string;
+		size?: 'sm' | 'default' | 'lg';
+		inline?: boolean;
+		showSpinner?: boolean;
+		align?: 'center' | 'start';
+		spinnerClass?: string;
+		textClass?: string;
+		class?: string;
+	} = $props();
+
+	const wrapperClasses = {
+		sm: inline ? 'text-sm' : 'py-8 text-sm',
+		default: inline ? 'text-base' : 'py-12 text-base',
+		lg: inline ? 'text-base' : 'py-16 text-base'
+	} as const;
+
+	const spinnerSizeClasses = {
+		sm: 'h-4 w-4',
+		default: 'h-6 w-6',
+		lg: 'h-8 w-8'
+	} as const;
+
+	const alignClass = align === 'start' ? 'justify-start' : 'justify-center';
+</script>
+
+<div class={`flex items-center ${alignClass} ${wrapperClasses[size]} ${className}`}>
+	{#if showSpinner}
+		<svg
+			class={`${spinnerSizeClasses[size]} animate-spin ${spinnerClass}`}
+			fill="none"
+			viewBox="0 0 24 24"
+		>
+			<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"
+			></circle>
+			<path
+				class="opacity-75"
+				fill="currentColor"
+				d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+			></path>
+		</svg>
+	{/if}
+	<div class={`${showSpinner ? 'ml-2' : ''} text-muted-foreground ${textClass}`}>{text}</div>
+</div>

--- a/web/src/lib/utils/live-event-source.ts
+++ b/web/src/lib/utils/live-event-source.ts
@@ -1,0 +1,69 @@
+type EventHandler = (event: MessageEvent, eventSource: EventSource) => void;
+
+type ManagedEventSourceOptions = {
+	url: string | null;
+	handlers?: Record<string, EventHandler>;
+	onError?: (eventSource: EventSource) => void;
+	onStop?: () => void;
+};
+
+export function createManagedEventSource() {
+	let eventSource: EventSource | null = null;
+	let currentUrl: string | null = null;
+
+	function isCurrent(source: EventSource) {
+		return eventSource === source;
+	}
+
+	function stop() {
+		if (eventSource) {
+			eventSource.close();
+			eventSource = null;
+		}
+		currentUrl = null;
+	}
+
+	function reset() {
+		stop();
+	}
+
+	function start({ url, handlers = {}, onError, onStop }: ManagedEventSourceOptions) {
+		if (!url) {
+			stop();
+			onStop?.();
+			return false;
+		}
+
+		if (eventSource && currentUrl === url) {
+			return false;
+		}
+
+		stop();
+		onStop?.();
+		currentUrl = url;
+
+		const source = new EventSource(url);
+		eventSource = source;
+
+		for (const [eventName, handler] of Object.entries(handlers)) {
+			source.addEventListener(eventName, (event) => {
+				handler(event as MessageEvent, source);
+			});
+		}
+
+		source.onerror = () => {
+			if (!isCurrent(source)) return;
+			onError?.(source);
+		};
+
+		return true;
+	}
+
+	return {
+		start,
+		stop,
+		reset,
+		isCurrent,
+		getCurrentUrl: () => currentUrl
+	};
+}

--- a/web/src/lib/utils/live-stream.ts
+++ b/web/src/lib/utils/live-stream.ts
@@ -1,0 +1,30 @@
+type QueryValue = string | number | boolean | null | undefined;
+
+function getAuthToken(): string | null {
+	if (typeof localStorage === 'undefined') {
+		return null;
+	}
+
+	return localStorage.getItem('auth_token');
+}
+
+export function buildAuthenticatedStreamUrl(
+	path: string,
+	params: Record<string, QueryValue> = {}
+): string | null {
+	const token = getAuthToken();
+	if (!token) {
+		return null;
+	}
+
+	const searchParams = new URLSearchParams();
+	for (const [key, value] of Object.entries(params)) {
+		if (value === undefined || value === null) {
+			continue;
+		}
+		searchParams.append(key, String(value));
+	}
+	searchParams.append('token', token);
+
+	return `${path}?${searchParams.toString()}`;
+}

--- a/web/src/lib/utils/submission.ts
+++ b/web/src/lib/utils/submission.ts
@@ -1,0 +1,13 @@
+import { formatTimestampOrFallback } from './timezone';
+
+export function formatSubmissionDateLabel(pubtime: string): string {
+	return formatTimestampOrFallback(pubtime, 'Asia/Shanghai', 'date', pubtime);
+}
+
+export function formatSubmissionMetricLabel(count: number): string {
+	if (count >= 10000) {
+		return `${(count / 10000).toFixed(1)}万`;
+	}
+
+	return count.toString();
+}

--- a/web/src/lib/utils/timezone.ts
+++ b/web/src/lib/utils/timezone.ts
@@ -3,6 +3,10 @@
 // 固定使用北京时间
 const BEIJING_TIMEZONE = 'Asia/Shanghai';
 
+function isBlankTimestamp(timestamp: string | number | Date | null | undefined): boolean {
+	return timestamp === null || timestamp === undefined || timestamp === '';
+}
+
 // 格式化时间戳到北京时间
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -60,6 +64,28 @@ export function formatTimestamp(
 		console.error('时间格式化失败:', error);
 		return '格式化失败';
 	}
+}
+
+export function isInvalidFormattedTime(value: string): boolean {
+	return value === '无效时间' || value === '格式化失败';
+}
+
+export function formatTimestampOrFallback(
+	timestamp: string | number | Date | null | undefined,
+	_timezone: string = BEIJING_TIMEZONE,
+	format: 'datetime' | 'date' | 'time' = 'datetime',
+	fallback?: string
+): string {
+	if (isBlankTimestamp(timestamp)) {
+		return fallback ?? '';
+	}
+
+	const formatted = formatTimestamp(timestamp as string | number | Date, _timezone, format);
+	if (isInvalidFormattedTime(formatted)) {
+		return fallback ?? String(timestamp);
+	}
+
+	return formatted;
 }
 
 // 获取相对时间描述

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
 	import InstallPrompt from '$lib/components/pwa/install-prompt.svelte';
 	import { Badge } from '$lib/components/ui/badge';
 	import { APP_VERSION } from '$lib/generated/app-version';
-	import { formatTimestamp } from '$lib/utils/timezone';
+	import { formatTimestampOrFallback } from '$lib/utils/timezone';
 	import { installGlossaryTooltips } from '$lib/utils/glossary-tooltip';
 
 	let dataLoaded = false;
@@ -81,12 +81,10 @@
 		}
 
 		function formatUpdateTime(ts?: string | null): string {
-			if (!ts) return '未知';
-			const formatted = formatTimestamp(ts, 'Asia/Shanghai', 'datetime');
-			if (formatted === '无效时间' || formatted === '格式化失败') {
-				return ts;
-			}
-			return formatted.replaceAll('/', '-');
+			return formatTimestampOrFallback(ts, 'Asia/Shanghai', 'datetime', ts ?? '未知').replaceAll(
+				'/',
+				'-'
+			);
 		}
 
 		const channel = betaImageUpdateStatus.release_channel ?? '未知';

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -24,6 +24,8 @@
 	} from '$lib/types';
 	import AuthLogin from '$lib/components/auth-login.svelte';
 	import InitialSetup from '$lib/components/initial-setup.svelte';
+	import EmptyState from '$lib/components/empty-state.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
 
 	// 图标导入
 	import CloudDownloadIcon from '@lucide/svelte/icons/cloud-download';
@@ -389,9 +391,7 @@
 {:else}
 	<div class="space-y-6">
 		{#if loading}
-			<div class="flex items-center justify-center py-12">
-				<div class="text-muted-foreground">加载中...</div>
-			</div>
+			<Loading />
 		{:else}
 			<!-- 第一行：存储空间 + 当前监听 -->
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -417,7 +417,7 @@
 								</div>
 							</div>
 						{:else}
-							<div class="text-muted-foreground text-sm">加载中...</div>
+							<Loading size="sm" align="start" textClass="text-sm" />
 						{/if}
 					</CardContent>
 				</Card>
@@ -541,7 +541,7 @@
 								</div>
 							</div>
 						{:else}
-							<div class="text-muted-foreground text-sm">加载中...</div>
+							<Loading size="sm" align="start" textClass="text-sm" />
 						{/if}
 					</CardContent>
 				</Card>
@@ -716,7 +716,7 @@
 								{/if}
 							</div>
 						{:else}
-							<div class="text-muted-foreground text-sm">加载中...</div>
+							<Loading size="sm" align="start" textClass="text-sm" />
 						{/if}
 					</CardContent>
 				</Card>
@@ -900,7 +900,7 @@
 			</Dialog.Header>
 			<div class="mt-2 max-h-[60vh] space-y-2 overflow-auto">
 				{#if latestIngests.length === 0}
-					<div class="text-muted-foreground py-8 text-center text-sm">暂无入库记录</div>
+					<EmptyState title="暂无入库记录" class="border-0 bg-transparent py-8" />
 				{:else}
 					{#each latestIngests as item (item.video_id)}
 						<div class="hover:bg-muted/30 rounded-lg border p-3 transition-colors">

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 	import api from '$lib/api';
 	import { wsManager } from '$lib/ws';
 	import { runRequest } from '$lib/utils/request.js';
-	import { formatTimestamp } from '$lib/utils/timezone';
+	import { formatTimestampOrFallback } from '$lib/utils/timezone';
 	import type {
 		DashBoardResponse,
 		SysInfo,
@@ -88,20 +88,11 @@
 
 	// 统一按北京时间显示（24小时制）
 	function formatTime(timeStr: string | null | undefined): string {
-		if (!timeStr) return '-';
-		const formatted = formatTimestamp(timeStr, BEIJING_TIMEZONE, 'time');
-		if (formatted === '无效时间' || formatted === '格式化失败') {
-			return timeStr;
-		}
-		return formatted;
+		return formatTimestampOrFallback(timeStr, BEIJING_TIMEZONE, 'time', timeStr ?? '-');
 	}
 
 	function formatChartTime(v: string | number): string {
-		const formatted = formatTimestamp(v, BEIJING_TIMEZONE, 'time');
-		if (formatted === '无效时间' || formatted === '格式化失败') {
-			return `${v}`;
-		}
-		return formatted;
+		return formatTimestampOrFallback(v, BEIJING_TIMEZONE, 'time', `${v}`);
 	}
 
 	// 从路径提取番剧名称（备用方案，当 series_name 不可用时）
@@ -406,10 +397,7 @@
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<Card class="lg:col-span-1">
 					<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle
-							class="text-sm font-medium"
-							title="显示当前磁盘可用空间、总容量和已用比例"
-						>
+						<CardTitle class="text-sm font-medium" title="显示当前磁盘可用空间、总容量和已用比例">
 							存储空间
 						</CardTitle>
 						<HardDriveIcon class="text-muted-foreground h-4 w-4" />
@@ -563,10 +551,7 @@
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<Card class="max-w-full overflow-hidden lg:col-span-2">
 					<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle
-							class="text-sm font-medium"
-							title="显示近七日新增视频统计和最近入库记录"
-						>
+						<CardTitle class="text-sm font-medium" title="显示近七日新增视频统计和最近入库记录">
 							最近入库
 						</CardTitle>
 						<VideoIcon class="text-muted-foreground h-4 w-4" />
@@ -636,10 +621,7 @@
 				</Card>
 				<Card class="max-w-full md:col-span-1">
 					<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle
-							class="text-sm font-medium"
-							title="显示下载与扫描任务的运行状态和控制入口"
-						>
+						<CardTitle class="text-sm font-medium" title="显示下载与扫描任务的运行状态和控制入口">
 							下载任务状态
 						</CardTitle>
 						<CloudDownloadIcon class="text-muted-foreground h-4 w-4" />
@@ -745,10 +727,7 @@
 				<!-- 内存使用情况 -->
 				<Card class="overflow-hidden">
 					<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle
-							class="text-sm font-medium"
-							title="显示系统总内存、已用内存和进程内存变化"
-						>
+						<CardTitle class="text-sm font-medium" title="显示系统总内存、已用内存和进程内存变化">
 							内存使用情况
 						</CardTitle>
 						<MemoryStickIcon class="text-muted-foreground h-4 w-4" />
@@ -823,10 +802,7 @@
 
 				<Card class="overflow-hidden">
 					<CardHeader class="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle
-							class="text-sm font-medium"
-							title="显示当前 CPU 使用率和最近一段时间的变化"
-						>
+						<CardTitle class="text-sm font-medium" title="显示当前 CPU 使用率和最近一段时间的变化">
 							CPU 使用情况
 						</CardTitle>
 						<CpuIcon class="text-muted-foreground h-4 w-4" />

--- a/web/src/routes/add-source/+page.svelte
+++ b/web/src/routes/add-source/+page.svelte
@@ -5,6 +5,8 @@
 	import BiliImage from '$lib/components/bili-image.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import EmptyState from '$lib/components/empty-state.svelte';
+	import SectionHeader from '$lib/components/section-header.svelte';
+	import SubmissionSelectionToolbar from '$lib/components/submission-selection-toolbar.svelte';
 	import SelectableCardButton from '$lib/components/selectable-card-button.svelte';
 	import SidePanel from '$lib/components/side-panel.svelte';
 	import { Input } from '$lib/components/ui/input';
@@ -41,6 +43,7 @@
 	import { runRequest } from '$lib/utils/request.js';
 	import { IsMobile, IsTablet } from '$lib/hooks/is-mobile.svelte.js';
 	import { formatTimestamp } from '$lib/utils/timezone';
+	import { formatSubmissionDateLabel, formatSubmissionMetricLabel } from '$lib/utils/submission';
 
 	let sourceType: VideoCategory = 'collection';
 	let lastSourceType: VideoCategory = sourceType; // 记录上一次的源类型，用于检测切换
@@ -1970,23 +1973,6 @@
 		// 保留已有的选择，不做清空
 	}
 
-	// 格式化时间
-	function formatSubmissionDate(pubtime: string): string {
-		const formatted = formatTimestamp(pubtime, 'Asia/Shanghai', 'date');
-		if (formatted === '无效时间' || formatted === '格式化失败') {
-			return pubtime;
-		}
-		return formatted;
-	}
-
-	// 格式化播放量
-	function formatSubmissionPlayCount(count: number): string {
-		if (count >= 10000) {
-			return (count / 10000).toFixed(1) + '万';
-		}
-		return count.toString();
-	}
-
 	// 当显示投稿选择且有sourceId时加载数据
 	$: if (showSubmissionSelection && sourceId && sourceType === 'submission') {
 		resetSubmissionState();
@@ -2413,7 +2399,14 @@
 	<div class="mx-auto px-4">
 		<div class="bg-card rounded-lg border p-6 shadow-sm">
 			<div class="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-				<h1 class="text-2xl font-bold">添加新视频源</h1>
+				<SectionHeader
+					as="h1"
+					title="添加新视频源"
+					description="搜索并配置收藏夹、合集、投稿、番剧或稍后再看等视频源。"
+					titleClass="text-2xl font-bold"
+					descriptionClass="text-muted-foreground mt-1 text-sm"
+					class="flex-1"
+				/>
 				{#if sourceType !== 'bangumi' && sourceType !== 'watch_later'}
 					<Button
 						variant={batchMode ? 'default' : 'outline'}
@@ -2683,7 +2676,8 @@
 											按同UP合集绝对顺序聚合
 										</div>
 										<p class="mt-1 text-xs text-blue-600 dark:text-blue-300">
-											开启后，该合集会归并到“同UP合集根目录”，并按该UP远端全部合集/系列列表的绝对顺序映射 Season xx。
+											开启后，该合集会归并到“同UP合集根目录”，并按该UP远端全部合集/系列列表的绝对顺序映射
+											Season xx。
 										</p>
 									</div>
 									<label class="relative inline-flex cursor-pointer items-center">
@@ -2879,7 +2873,9 @@
 												如果使用 Docker 部署并设置了卷映射，请填写容器内路径。
 											</p>
 											<p class="text-muted-foreground mt-1 text-xs">
-												例如映射 <code class="bg-muted rounded px-1">/volume1/Videos:/Downloads</code>
+												例如映射 <code class="bg-muted rounded px-1"
+													>/volume1/Videos:/Downloads</code
+												>
 											</p>
 											<p class="text-muted-foreground text-xs">
 												则应填写 <code class="bg-muted rounded px-1">/Downloads</code>
@@ -3704,7 +3700,11 @@
 
 						<!-- 提交按钮 -->
 						<div class="flex {isMobile ? 'flex-col' : ''} gap-2">
-							<Button type="submit" disabled={loading || batchMode} class={isMobile ? 'w-full' : ''}>
+							<Button
+								type="submit"
+								disabled={loading || batchMode}
+								class={isMobile ? 'w-full' : ''}
+							>
 								{loading ? '添加中...' : '添加'}
 							</Button>
 							<Button
@@ -3861,7 +3861,7 @@
 												<p class="text-muted-foreground truncate text-xs">
 													{result.author}{#if result.result_type === 'bili_user' && result.follower !== undefined && result.follower !== null}
 														<span class="ml-2"
-															>· 粉丝: {formatSubmissionPlayCount(result.follower)}</span
+															>· 粉丝: {formatSubmissionMetricLabel(result.follower)}</span
 														>
 													{/if}
 												</p>
@@ -3971,7 +3971,7 @@
 												<p class="text-muted-foreground mb-1 truncate text-xs">
 													UID: {following.mid}{#if following.follower !== undefined && following.follower !== null}
 														<span class="ml-2"
-															>· 粉丝: {formatSubmissionPlayCount(following.follower)}</span
+															>· 粉丝: {formatSubmissionMetricLabel(following.follower)}</span
 														>
 													{/if}
 												</p>
@@ -4065,11 +4065,7 @@
 													>
 														{collection.collection_type === 'season' ? '合集' : '系列'}
 													</span>
-													{#if isCollectionExists(
-														collection.sid,
-														collection.mid.toString(),
-														collection.collection_type
-													)}
+													{#if isCollectionExists(collection.sid, collection.mid.toString(), collection.collection_type)}
 														<span
 															class="flex-shrink-0 rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300"
 														>
@@ -4658,83 +4654,22 @@
 								</div>
 							{:else}
 								<!-- 搜索和操作栏 -->
-								<div class="flex-shrink-0 space-y-3 p-3">
-									<div class="flex gap-2">
-										<div class="relative flex-1">
-											<input
-												type="text"
-												bind:value={submissionSearchQuery}
-												placeholder="搜索视频标题（支持关键词搜索UP主所有视频）..."
-												class="w-full rounded-md border border-gray-300 px-3 py-2 pr-8 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-												disabled={isSearching}
-											/>
-											{#if isSearching}
-												<div class="absolute inset-y-0 right-0 flex items-center pr-3">
-													<svg
-														class="h-4 w-4 animate-spin text-blue-600"
-														fill="none"
-														viewBox="0 0 24 24"
-													>
-														<circle
-															class="opacity-25"
-															cx="12"
-															cy="12"
-															r="10"
-															stroke="currentColor"
-															stroke-width="4"
-														></circle>
-														<path
-															class="opacity-75"
-															fill="currentColor"
-															d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-														></path>
-													</svg>
-												</div>
-											{/if}
-										</div>
-									</div>
-
-									{#if submissionSearchQuery.trim()}
-										<div class="px-1 text-xs text-blue-600">
-											{isSearching
-												? '搜索中...'
-												: `搜索模式：在UP主所有视频中搜索 "${submissionSearchQuery}"`}
-										</div>
-									{/if}
-
-									<div class="flex items-center justify-between">
-										<div class="flex gap-2">
-											<button
-												type="button"
-												class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-3 py-1 text-sm font-medium"
-												onclick={selectAllSubmissions}
-												disabled={filteredSubmissionVideos.length === 0}
-											>
-												全选
-											</button>
-											<button
-												type="button"
-												class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-3 py-1 text-sm font-medium"
-												onclick={selectNoneSubmissions}
-												disabled={selectedSubmissionCount === 0}
-											>
-												全不选
-											</button>
-											<button
-												type="button"
-												class="bg-card text-foreground hover:bg-muted rounded-md border border-gray-300 px-3 py-1 text-sm font-medium"
-												onclick={invertSubmissionSelection}
-												disabled={filteredSubmissionVideos.length === 0}
-											>
-												反选
-											</button>
-										</div>
-
-										<div class="text-muted-foreground text-sm">
-											已选择 {selectedSubmissionCount} / {filteredSubmissionVideos.length} 个视频
-										</div>
-									</div>
-								</div>
+								<SubmissionSelectionToolbar
+									bind:query={submissionSearchQuery}
+									placeholder="搜索视频标题（支持关键词搜索UP主所有视频）..."
+									{isSearching}
+									statusText={isSearching
+										? '搜索中...'
+										: `搜索模式：在UP主所有视频中搜索 \"${submissionSearchQuery}\"`}
+									selectedCount={selectedSubmissionCount}
+									totalCount={filteredSubmissionVideos.length}
+									onSelectAll={selectAllSubmissions}
+									onSelectNone={selectNoneSubmissions}
+									onInvert={invertSubmissionSelection}
+									selectAllDisabled={filteredSubmissionVideos.length === 0}
+									selectNoneDisabled={selectedSubmissionCount === 0}
+									invertDisabled={filteredSubmissionVideos.length === 0}
+								/>
 
 								<!-- 视频列表 -->
 								<div
@@ -4803,7 +4738,9 @@
 														video.bvid
 													)
 														? 'border-blue-300 bg-blue-50 dark:border-blue-600 dark:bg-blue-950'
-														: 'border-gray-200 dark:border-gray-700'} {isMobile ? 'h-auto' : 'h-[100px]'}"
+														: 'border-gray-200 dark:border-gray-700'} {isMobile
+														? 'h-auto'
+														: 'h-[100px]'}"
 													onclick={() => toggleSubmissionVideo(video.bvid)}
 													onkeydown={(event) => handleSubmissionCardKeydown(event, video.bvid)}
 												>
@@ -4836,9 +4773,9 @@
 															</p>
 															<div class="text-muted-foreground mt-auto text-xs">
 																<div class="flex flex-wrap items-center gap-2">
-																	<span>🎬 {formatSubmissionPlayCount(video.view)}</span>
-																	<span>💬 {formatSubmissionPlayCount(video.danmaku)}</span>
-																	<span>📅 {formatSubmissionDate(video.pubtime)}</span>
+																	<span>🎬 {formatSubmissionMetricLabel(video.view)}</span>
+																	<span>💬 {formatSubmissionMetricLabel(video.danmaku)}</span>
+																	<span>📅 {formatSubmissionDateLabel(video.pubtime)}</span>
 																	<span class="font-mono text-xs">{video.bvid}</span>
 																</div>
 															</div>
@@ -5129,7 +5066,9 @@
 						class="mt-1"
 					/>
 					{#if batchSelectedTemplate}
-						<div class="mt-2 space-y-1 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+						<div
+							class="mt-2 space-y-1 rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30"
+						>
 							<p class="text-xs text-blue-700 dark:text-blue-300">
 								已从当前源类型的快捷订阅路径模板带入默认值，本次批量添加可临时改成任意路径或任意模板。
 							</p>
@@ -5139,7 +5078,9 @@
 						</div>
 					{:else}
 						<p class="text-muted-foreground mt-1 text-xs">
-							未配置快捷模板时，所有选中的视频源将保存到此路径。支持手动填写 <code>{'{{name}}'}</code> 变量。
+							未配置快捷模板时，所有选中的视频源将保存到此路径。支持手动填写 <code
+								>{'{{name}}'}</code
+							> 变量。
 						</p>
 					{/if}
 				</div>
@@ -5155,7 +5096,8 @@
 									按同UP合集绝对顺序聚合
 								</div>
 								<p class="mt-1 text-xs text-blue-600 dark:text-blue-300">
-									批量添加的合集源将按各自UP远端合集/系列列表顺序映射 Season xx，并归并到对应UP合集根目录。
+									批量添加的合集源将按各自UP远端合集/系列列表顺序映射 Season
+									xx，并归并到对应UP合集根目录。
 								</p>
 							</div>
 							<label class="relative inline-flex cursor-pointer items-center">

--- a/web/src/routes/add-source/+page.svelte
+++ b/web/src/routes/add-source/+page.svelte
@@ -9,6 +9,8 @@
 	import SubmissionSelectionToolbar from '$lib/components/submission-selection-toolbar.svelte';
 	import SelectableCardButton from '$lib/components/selectable-card-button.svelte';
 	import SidePanel from '$lib/components/side-panel.svelte';
+	import SelectAllButton from '$lib/components/select-all-button.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
@@ -3736,14 +3738,7 @@
 						>
 							{#snippet actions()}
 								{#if batchMode && sourceType === 'submission'}
-									<Button
-										size="sm"
-										variant="outline"
-										onclick={() => selectAllVisible('search')}
-										class="text-xs"
-									>
-										全选
-									</Button>
+									<SelectAllButton onclick={() => selectAllVisible('search')} />
 								{/if}
 								<button
 									onclick={() => {
@@ -3901,14 +3896,7 @@
 							showActions={batchMode}
 						>
 							{#snippet actions()}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => selectAllVisible('following')}
-									class="text-xs"
-								>
-									全选
-								</Button>
+								<SelectAllButton onclick={() => selectAllVisible('following')} />
 							{/snippet}
 
 							<div
@@ -4002,14 +3990,7 @@
 							showActions={batchMode}
 						>
 							{#snippet actions()}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => selectAllVisible('collection')}
-									class="text-xs"
-								>
-									全选
-								</Button>
+								<SelectAllButton onclick={() => selectAllVisible('collection')} />
 							{/snippet}
 
 							<div
@@ -4109,14 +4090,7 @@
 							showActions={batchMode}
 						>
 							{#snippet actions()}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => selectAllVisible('favorite')}
-									class="text-xs"
-								>
-									全选
-								</Button>
+								<SelectAllButton onclick={() => selectAllVisible('favorite')} />
 							{/snippet}
 
 							<div
@@ -4205,14 +4179,7 @@
 						>
 							{#snippet actions()}
 								{#if batchMode && searchedUserFavorites.length > 0}
-									<Button
-										size="sm"
-										variant="outline"
-										onclick={() => selectAllVisible('searched-favorite')}
-										class="text-xs"
-									>
-										全选
-									</Button>
+									<SelectAllButton onclick={() => selectAllVisible('searched-favorite')} />
 								{/if}
 								<button
 									onclick={clearSearchedUserFavoritesSelection}
@@ -4224,9 +4191,11 @@
 
 							{#if loadingSearchedUserFavorites}
 								<div class="p-4 text-center">
-									<div class="text-sm text-green-700 dark:text-green-300">
-										正在获取收藏夹列表...
-									</div>
+									<Loading
+										size="sm"
+										text="正在获取收藏夹列表..."
+										textClass="text-sm text-green-700 dark:text-green-300"
+									/>
 								</div>
 							{:else if searchedUserFavorites.length > 0}
 								<div
@@ -4476,14 +4445,7 @@
 							showActions={batchMode}
 						>
 							{#snippet actions()}
-								<Button
-									size="sm"
-									variant="outline"
-									onclick={() => selectAllVisible('subscribed-collection')}
-									class="text-xs"
-								>
-									全选
-								</Button>
+								<SelectAllButton onclick={() => selectAllVisible('subscribed-collection')} />
 							{/snippet}
 
 							<div
@@ -4678,28 +4640,12 @@
 									onscroll={handleSubmissionScroll}
 								>
 									{#if submissionLoading && submissionVideos.length === 0}
-										<div class="flex items-center justify-center py-8">
-											<svg
-												class="h-8 w-8 animate-spin text-blue-600 dark:text-blue-400"
-												fill="none"
-												viewBox="0 0 24 24"
-											>
-												<circle
-													class="opacity-25"
-													cx="12"
-													cy="12"
-													r="10"
-													stroke="currentColor"
-													stroke-width="4"
-												></circle>
-												<path
-													class="opacity-75"
-													fill="currentColor"
-													d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-												></path>
-											</svg>
-											<span class="text-muted-foreground ml-2 text-sm">加载中...</span>
-										</div>
+										<Loading
+											showSpinner={true}
+											spinnerClass="text-blue-600 dark:text-blue-400"
+											textClass="text-sm"
+											class="py-8"
+										/>
 									{:else if filteredSubmissionVideos.length === 0}
 										<EmptyState
 											icon={Search}
@@ -4795,12 +4741,13 @@
 														disabled={isLoadingMore}
 													>
 														{#if isLoadingMore}
-															<div class="flex items-center gap-2">
-																<div
-																	class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"
-																></div>
-																<span>加载中...</span>
-															</div>
+															<Loading
+																inline={true}
+																showSpinner={true}
+																spinnerClass="text-white"
+																textClass="text-white"
+																class="gap-2"
+															/>
 														{:else}
 															加载更多 ({submissionVideos.length}/{submissionTotalCount})
 														{/if}

--- a/web/src/routes/queue/+page.svelte
+++ b/web/src/routes/queue/+page.svelte
@@ -24,14 +24,16 @@
 	import type { QueueStatusResponse } from '$lib/types';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
 	import { runRequest } from '$lib/utils/request.js';
-	import { formatTimestamp } from '$lib/utils/timezone';
+	import { formatTimestampOrFallback } from '$lib/utils/timezone';
+	import { buildAuthenticatedStreamUrl } from '$lib/utils/live-stream';
+	import { createManagedEventSource } from '$lib/utils/live-event-source';
+	import SectionHeader from '$lib/components/section-header.svelte';
 	import { toast } from 'svelte-sonner';
 
 	let queueStatus: QueueStatusResponse | null = null;
 	let loading = true;
 	let error: string | null = null;
-	let queueEventSource: EventSource | null = null;
-	let currentQueueStreamUrl: string | null = null;
+	const queueStream = createManagedEventSource();
 	let cancellingTaskIds: Record<string, boolean> = {};
 
 	// 设置面包屑
@@ -58,46 +60,28 @@
 	}
 
 	function buildQueueStreamUrl(): string | null {
-		const token = localStorage.getItem('auth_token');
-		if (!token) return null;
-
-		const params = new URLSearchParams();
-		params.append('token', token);
-		return `/api/queue/live?${params.toString()}`;
+		return buildAuthenticatedStreamUrl('/api/queue/live');
 	}
 
 	function stopQueueStream() {
-		if (queueEventSource) {
-			queueEventSource.close();
-			queueEventSource = null;
-		}
-		currentQueueStreamUrl = null;
+		queueStream.stop();
 	}
 
 	function startQueueStream() {
-		const streamUrl = buildQueueStreamUrl();
-		if (!streamUrl) return;
-		if (queueEventSource && currentQueueStreamUrl === streamUrl) return;
-
-		stopQueueStream();
-		currentQueueStreamUrl = streamUrl;
-
-		const eventSource = new EventSource(streamUrl);
-		queueEventSource = eventSource;
-
-		eventSource.addEventListener('queue', (event) => {
-			try {
-				queueStatus = JSON.parse((event as MessageEvent).data) as QueueStatusResponse;
-				error = null;
-				loading = false;
-			} catch (err) {
-				console.error('解析任务队列实时更新失败:', err);
+		queueStream.start({
+			url: buildQueueStreamUrl(),
+			handlers: {
+				queue: (event) => {
+					try {
+						queueStatus = JSON.parse(event.data) as QueueStatusResponse;
+						error = null;
+						loading = false;
+					} catch (err) {
+						console.error('解析任务队列实时更新失败:', err);
+					}
+				}
 			}
 		});
-
-		eventSource.onerror = () => {
-			if (queueEventSource !== eventSource) return;
-		};
 	}
 
 	// 手动刷新
@@ -109,11 +93,7 @@
 
 	// 格式化时间
 	function formatTime(timeString: string): string {
-		const formatted = formatTimestamp(timeString, 'Asia/Shanghai', 'time');
-		if (formatted === '无效时间' || formatted === '格式化失败') {
-			return '无效时间';
-		}
-		return formatted;
+		return formatTimestampOrFallback(timeString, 'Asia/Shanghai', 'time', '无效时间');
 	}
 
 	// 获取任务类型的显示名称
@@ -196,16 +176,21 @@
 </script>
 
 <div class="container mx-auto px-4">
-	<div class="mb-6 flex items-center justify-between">
-		<div>
-			<h1 class="text-3xl font-bold">任务队列</h1>
-			<p class="text-muted-foreground mt-2">查看和管理系统任务队列状态</p>
-		</div>
-		<Button variant="outline" size="sm" onclick={handleRefresh} disabled={loading}>
-			<RefreshCw class="mr-2 h-4 w-4 {loading ? 'animate-spin' : ''}" />
-			刷新
-		</Button>
-	</div>
+	<SectionHeader
+		as="h1"
+		title="任务队列"
+		description="查看和管理系统任务队列状态"
+		titleClass="text-3xl font-bold"
+		descriptionClass="text-muted-foreground mt-2"
+		class="mb-6"
+	>
+		{#snippet actions()}
+			<Button variant="outline" size="sm" onclick={handleRefresh} disabled={loading}>
+				<RefreshCw class="mr-2 h-4 w-4 {loading ? 'animate-spin' : ''}" />
+				刷新
+			</Button>
+		{/snippet}
+	</SectionHeader>
 
 	{#if error}
 		<Card class="border-destructive">

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -33,6 +33,7 @@
 	import { IsMobile, IsTablet } from '$lib/hooks/is-mobile.svelte.js';
 	// import type { Theme } from '$lib/stores/theme'; // 未使用，已注释
 	import ThemeToggle from '$lib/components/theme-toggle.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
 
 	let config: ConfigResponse | null = null;
 	let loading = false;
@@ -151,7 +152,8 @@
 	let folderStructure = 'Season {{season_pad}}';
 	let bangumiFolderName = '{{title}}';
 	let collectionFolderMode = 'unified';
-	let collectionUnifiedName = 'S01E{{episode_pad}}{{#if is_multi_page}}P{{pid_pad}}{{/if}} - {{title}}';
+	let collectionUnifiedName =
+		'S01E{{episode_pad}}{{#if is_multi_page}}P{{pid_pad}}{{/if}} - {{title}}';
 	let timeFormat = '%Y-%m-%d';
 	let interval = 1200;
 	let nfoTimeType = 'favtime';
@@ -1261,9 +1263,7 @@
 			</h1>
 
 			{#if loading}
-				<div class="flex items-center justify-center py-12">
-					<div class="text-muted-foreground">加载中...</div>
-				</div>
+				<Loading />
 			{:else}
 				<!-- 设置分类卡片列表 -->
 				<div
@@ -1324,10 +1324,7 @@
 		class="flex flex-col {isMobile ? 'h-[calc(90vh-8rem)]' : 'h-[calc(100vh-12rem)]'}"
 	>
 		<div class="min-h-0 flex-1 space-y-6 overflow-y-auto {isMobile ? 'px-4 py-4' : 'px-6 py-6'}">
-			<SectionHeader
-				title="文件命名模板"
-				titleTooltip="配置视频、分页和番剧的命名模板与变量规则。"
-			>
+			<SectionHeader title="文件命名模板" titleTooltip="配置视频、分页和番剧的命名模板与变量规则。">
 				{#snippet actions()}
 					<button
 						type="button"
@@ -2227,8 +2224,10 @@
 
 				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 					<div class="space-y-2">
-						<Label for="danmaku-update-fresh-days" class="cursor-help" title={danmakuUpdateHelp.freshDays}
-							>新鲜期天数</Label
+						<Label
+							for="danmaku-update-fresh-days"
+							class="cursor-help"
+							title={danmakuUpdateHelp.freshDays}>新鲜期天数</Label
 						>
 						<Input
 							id="danmaku-update-fresh-days"
@@ -2295,8 +2294,10 @@
 					</div>
 
 					<div class="space-y-2">
-						<Label for="danmaku-update-cold-days" class="cursor-help" title={danmakuUpdateHelp.coldDays}
-							>老化期截至天数</Label
+						<Label
+							for="danmaku-update-cold-days"
+							class="cursor-help"
+							title={danmakuUpdateHelp.coldDays}>老化期截至天数</Label
 						>
 						<Input
 							id="danmaku-update-cold-days"
@@ -2649,7 +2650,8 @@
 					</div>
 					<div class="rounded-md bg-yellow-50 p-3 dark:bg-yellow-950/20">
 						<p class="text-xs text-yellow-800 dark:text-yellow-200">
-							动态API每次最多返回 12 条记录。首次全量扫描请求次数多，建议保持启用延迟，后续增量扫描耗时较小。
+							动态API每次最多返回 12
+							条记录。首次全量扫描请求次数多，建议保持启用延迟，后续增量扫描耗时较小。
 						</p>
 					</div>
 				</div>
@@ -3185,7 +3187,9 @@
 					<div class="space-y-1">
 						<h4 class="text-sm font-medium">快捷订阅路径模板</h4>
 						<p class="text-muted-foreground text-sm">
-							添加收藏夹、合集、UP主投稿、番剧源时可直接带出保存路径。支持使用 <code>{'{{name}}'}</code>
+							添加收藏夹、合集、UP主投稿、番剧源时可直接带出保存路径。支持使用 <code
+								>{'{{name}}'}</code
+							>
 							代表源名称。
 						</p>
 					</div>
@@ -3412,7 +3416,8 @@
 							<option value="custom">自定义 JSON</option>
 						</select>
 						<p class="text-muted-foreground text-sm">
-							自动识别会根据URL判断；openSend 会发送其专用字段并附带 apikey 头；自定义 JSON 可自行定义 POST Body 结构
+							自动识别会根据URL判断；openSend 会发送其专用字段并附带 apikey 头；自定义 JSON
+							可自行定义 POST Body 结构
 						</p>
 					</div>
 
@@ -3453,8 +3458,13 @@
 						/>
 						<div class="text-muted-foreground space-y-1 text-sm">
 							<p>请填写 JSON 对象，键和值都必须是字符串。</p>
-							<p>例如：<code>{'{"Authorization":"Bearer your-token","X-Channel":"clawbot"}'}</code></p>
-							<p>如与自动附带的 Bearer Token 或 openSend 的 apikey 同名，自定义 Headers 会覆盖默认值。</p>
+							<p>
+								例如：<code>{'{"Authorization":"Bearer your-token","X-Channel":"clawbot"}'}</code>
+							</p>
+							<p>
+								如与自动附带的 Bearer Token 或 openSend 的 apikey 同名，自定义 Headers
+								会覆盖默认值。
+							</p>
 						</div>
 					</div>
 
@@ -3481,14 +3491,19 @@
 								class="font-mono text-xs"
 							/>
 							<div class="text-muted-foreground space-y-1 text-sm">
-								<p>支持占位符：&#123;&#123;source&#125;&#125;、&#123;&#123;title&#125;&#125;、&#123;&#123;content&#125;&#125;、&#123;&#123;channel&#125;&#125;、&#123;&#123;event&#125;&#125;、&#123;&#123;sent_at&#125;&#125;</p>
+								<p>
+									支持占位符：&#123;&#123;source&#125;&#125;、&#123;&#123;title&#125;&#125;、&#123;&#123;content&#125;&#125;、&#123;&#123;channel&#125;&#125;、&#123;&#123;event&#125;&#125;、&#123;&#123;sent_at&#125;&#125;
+								</p>
 								<p>&#123;&#123;source&#125;&#125;：固定来源名，当前为 bili-sync</p>
 								<p>&#123;&#123;title&#125;&#125;：推送标题</p>
 								<p>&#123;&#123;content&#125;&#125;：推送正文内容</p>
 								<p>&#123;&#123;channel&#125;&#125;：当前通知渠道名称，例如 webhook</p>
 								<p>&#123;&#123;event&#125;&#125;：事件类型，例如 test_notification</p>
 								<p>&#123;&#123;sent_at&#125;&#125;：发送时间</p>
-								<p>请直接填写有效 JSON。若某个值只写占位符，发送时会按原始类型写入；若嵌在字符串中，则会按文本替换。</p>
+								<p>
+									请直接填写有效
+									JSON。若某个值只写占位符，发送时会按原始类型写入；若嵌在字符串中，则会按文本替换。
+								</p>
 							</div>
 						</div>
 					{/if}

--- a/web/src/routes/video-sources/+page.svelte
+++ b/web/src/routes/video-sources/+page.svelte
@@ -20,6 +20,9 @@
 	import KeywordFilterDialog from '$lib/components/keyword-filter-dialog.svelte';
 	import AiPromptDialog from '$lib/components/ai-prompt-dialog.svelte';
 	import SectionHeader from '$lib/components/section-header.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
+	import SelectAllButton from '$lib/components/select-all-button.svelte';
+	import EmptyState from '$lib/components/empty-state.svelte';
 	import AiRenameHistoryDialog from '$lib/components/ai-rename-history-dialog.svelte';
 	import type { VideoSource, VideoSourcesResponse } from '$lib/types';
 
@@ -1094,9 +1097,7 @@
 	</SectionHeader>
 
 	{#if loading}
-		<div class="flex items-center justify-center py-12">
-			<div class="text-muted-foreground">加载中...</div>
-		</div>
+		<Loading />
 	{:else}
 		<!-- 视频源分类展示 -->
 		<div class="grid gap-6">
@@ -1188,14 +1189,11 @@
 										</span>
 
 										<div class="ml-auto flex flex-wrap items-center gap-2">
-											<Button
-												size="sm"
-												variant="outline"
+											<SelectAllButton
 												disabled={bulkUpdating}
 												onclick={() => selectAll(sourceKey, sources)}
-											>
-												全选
-											</Button>
+												className="text-sm"
+											/>
 											<Button
 												size="sm"
 												variant="outline"
@@ -1642,25 +1640,25 @@
 									{/each}
 								</div>
 							{:else}
-								<div class="flex flex-col items-center justify-center py-8 text-center">
-									<sourceConfig.icon class="text-muted-foreground mb-4 h-12 w-12" />
-									<div class="text-muted-foreground mb-2">暂无{sourceConfig.title}</div>
-									<p class="text-muted-foreground mb-4 text-sm">
-										{#if sourceConfig.type === 'favorite'}
-											还没有添加任何收藏夹订阅
-										{:else if sourceConfig.type === 'collection'}
-											还没有添加任何合集或列表订阅
-										{:else if sourceConfig.type === 'submission'}
-											还没有添加任何UP主投稿订阅
-										{:else}
-											还没有添加稍后再看订阅
-										{/if}
-									</p>
-									<Button size="sm" variant="outline" onclick={navigateToAddSource}>
-										<PlusIcon class="mr-2 h-4 w-4" />
-										添加{sourceConfig.title}
-									</Button>
-								</div>
+								<EmptyState
+									icon={sourceConfig.icon}
+									title={`暂无${sourceConfig.title}`}
+									description={sourceConfig.type === 'favorite'
+										? '还没有添加任何收藏夹订阅'
+										: sourceConfig.type === 'collection'
+											? '还没有添加任何合集或列表订阅'
+											: sourceConfig.type === 'submission'
+												? '还没有添加任何UP主投稿订阅'
+												: '还没有添加稍后再看订阅'}
+									class="py-8"
+								>
+									{#snippet actions()}
+										<Button size="sm" variant="outline" onclick={navigateToAddSource}>
+											<PlusIcon class="mr-2 h-4 w-4" />
+											添加{sourceConfig.title}
+										</Button>
+									{/snippet}
+								</EmptyState>
 							{/if}
 						</CardContent>
 					{/if}

--- a/web/src/routes/video-sources/+page.svelte
+++ b/web/src/routes/video-sources/+page.svelte
@@ -19,6 +19,7 @@
 	import SubmissionSelectionDialog from '$lib/components/submission-selection-dialog.svelte';
 	import KeywordFilterDialog from '$lib/components/keyword-filter-dialog.svelte';
 	import AiPromptDialog from '$lib/components/ai-prompt-dialog.svelte';
+	import SectionHeader from '$lib/components/section-header.svelte';
 	import AiRenameHistoryDialog from '$lib/components/ai-rename-history-dialog.svelte';
 	import type { VideoSource, VideoSourcesResponse } from '$lib/types';
 
@@ -41,12 +42,13 @@
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import HistoryIcon from '@lucide/svelte/icons/history';
 	import { goto } from '$app/navigation';
-	import { formatTimestamp } from '$lib/utils/timezone';
+	import { formatTimestampOrFallback } from '$lib/utils/timezone';
+	import { buildAuthenticatedStreamUrl } from '$lib/utils/live-stream';
+	import { createManagedEventSource } from '$lib/utils/live-event-source';
 
 	let loading = false;
 	let bulkUpdating = false;
-	let sourcesEventSource: EventSource | null = null;
-	let currentSourcesStreamUrl: string | null = null;
+	const videoSourcesStream = createManagedEventSource();
 	const queuedDeleteNoticeMap = new Map<
 		string,
 		{ sourceType: VideoSourceType; sourceId: number; sourceName: string }
@@ -139,9 +141,7 @@
 
 	function formatLatestVideoTime(value: string | null | undefined): string {
 		const normalized = normalizeBeijingDateTime(value);
-		if (!normalized) return '-';
-		const formatted = formatTimestamp(normalized, 'Asia/Shanghai', 'datetime');
-		return formatted === '无效时间' || formatted === '格式化失败' ? value ?? '-' : formatted;
+		return formatTimestampOrFallback(normalized, 'Asia/Shanghai', 'datetime', value ?? '-');
 	}
 
 	function getLatestVideoAgeDays(value: string | null | undefined): number | null {
@@ -180,13 +180,7 @@
 	}
 
 	function buildVideoSourcesStreamUrl(): string | null {
-		if (typeof localStorage === 'undefined') return null;
-		const token = localStorage.getItem('auth_token');
-		if (!token) return null;
-
-		const searchParams = new URLSearchParams();
-		searchParams.append('token', token);
-		return `/api/video-sources/live?${searchParams.toString()}`;
+		return buildAuthenticatedStreamUrl('/api/video-sources/live');
 	}
 
 	function sourceStillExists(
@@ -223,44 +217,27 @@
 	}
 
 	function stopVideoSourcesStream() {
-		if (sourcesEventSource) {
-			sourcesEventSource.close();
-			sourcesEventSource = null;
-		}
-		currentSourcesStreamUrl = null;
+		videoSourcesStream.stop();
 	}
 
 	function startVideoSourcesStream() {
-		const streamUrl = buildVideoSourcesStreamUrl();
-		if (!streamUrl) {
-			stopVideoSourcesStream();
-			return;
-		}
-
-		if (sourcesEventSource && currentSourcesStreamUrl === streamUrl) {
-			return;
-		}
-
-		stopVideoSourcesStream();
-		currentSourcesStreamUrl = streamUrl;
-
-		const eventSource = new EventSource(streamUrl);
-		sourcesEventSource = eventSource;
-
-		eventSource.addEventListener('sources', (event) => {
-			try {
-				const payload = JSON.parse((event as MessageEvent).data) as VideoSourcesResponse;
-				notifyCompletedQueuedDeletions(payload);
-				setVideoSources(payload);
-			} catch (error) {
-				console.error('解析视频源实时更新失败:', error);
+		videoSourcesStream.start({
+			url: buildVideoSourcesStreamUrl(),
+			handlers: {
+				sources: (event) => {
+					try {
+						const payload = JSON.parse(event.data) as VideoSourcesResponse;
+						notifyCompletedQueuedDeletions(payload);
+						setVideoSources(payload);
+					} catch (error) {
+						console.error('解析视频源实时更新失败:', error);
+					}
+				}
+			},
+			onError: () => {
+				console.warn('视频源实时更新连接异常，等待浏览器自动重连');
 			}
 		});
-
-		eventSource.onerror = () => {
-			if (sourcesEventSource !== eventSource) return;
-			console.warn('视频源实时更新连接异常，等待浏览器自动重连');
-		};
 	}
 
 	// 投稿源扫描策略配置（分批/自适应）
@@ -1096,27 +1073,25 @@
 
 <div class="space-y-6">
 	<!-- 页面头部 -->
-	<div class="flex {isMobile ? 'flex-col gap-4' : 'flex-row items-center justify-between gap-4'}">
-		<div>
-			<h1
-				class="{isMobile ? 'text-xl' : 'text-2xl'} font-bold"
-				title="管理和配置收藏夹、合集、投稿、番剧与稍后再看视频源"
+	<SectionHeader
+		as="h1"
+		title="视频源管理"
+		description="管理和配置您的视频源，包括收藏夹、合集、投稿和稍后再看。"
+		titleTooltip="管理和配置收藏夹、合集、投稿、番剧与稍后再看视频源"
+		titleClass="font-bold {isMobile ? 'text-xl' : 'text-2xl'}"
+		descriptionClass="text-muted-foreground {isMobile ? 'text-sm' : 'text-base'} mt-1"
+	>
+		{#snippet actions()}
+			<Button
+				onclick={navigateToAddSource}
+				class="flex items-center gap-2 {isMobile ? 'w-full' : 'w-auto'}"
+				title="添加新的视频源"
 			>
-				视频源管理
-			</h1>
-			<p class="{isMobile ? 'text-sm' : 'text-base'} text-muted-foreground">
-				管理和配置您的视频源，包括收藏夹、合集、投稿和稍后再看
-			</p>
-		</div>
-		<Button
-			onclick={navigateToAddSource}
-			class="flex items-center gap-2 {isMobile ? 'w-full' : 'w-auto'}"
-			title="添加新的视频源"
-		>
-			<PlusIcon class="h-4 w-4" />
-			添加视频源
-		</Button>
-	</div>
+				<PlusIcon class="h-4 w-4" />
+				添加视频源
+			</Button>
+		{/snippet}
+	</SectionHeader>
 
 	{#if loading}
 		<div class="flex items-center justify-center py-12">
@@ -1280,23 +1255,23 @@
 														{source.enabled ? '已启用' : '已禁用'}
 													</Badge>
 												</div>
-											<div class="text-muted-foreground truncate text-sm" title={source.path}>
-												{source.path || '未设置路径'}
-											</div>
-											<div
-												class="text-muted-foreground mt-1 flex items-center gap-2 text-xs"
-												title="该视频源当前已发现的最新一条视频发布时间。最近 7 天内为绿色，8 到 30 天为黄色，31 天及以上为红色，可用于判断这个源最近是否还有更新"
-											>
-												<span>最新视频时间：</span>
-												<Badge
-													variant="outline"
-													class={getLatestVideoTimeBadgeClass(source.latest_row_at)}
+												<div class="text-muted-foreground truncate text-sm" title={source.path}>
+													{source.path || '未设置路径'}
+												</div>
+												<div
+													class="text-muted-foreground mt-1 flex items-center gap-2 text-xs"
+													title="该视频源当前已发现的最新一条视频发布时间。最近 7 天内为绿色，8 到 30 天为黄色，31 天及以上为红色，可用于判断这个源最近是否还有更新"
 												>
-													{formatLatestVideoTime(source.latest_row_at)}
-												</Badge>
-											</div>
-											<!-- 显示对应类型的ID -->
-											<div class="text-muted-foreground mt-1 text-xs">
+													<span>最新视频时间：</span>
+													<Badge
+														variant="outline"
+														class={getLatestVideoTimeBadgeClass(source.latest_row_at)}
+													>
+														{formatLatestVideoTime(source.latest_row_at)}
+													</Badge>
+												</div>
+												<!-- 显示对应类型的ID -->
+												<div class="text-muted-foreground mt-1 text-xs">
 													{#if sourceConfig.type === 'favorite' && source.f_id}
 														收藏夹ID: {source.f_id}
 													{:else if sourceConfig.type === 'collection' && source.s_id}

--- a/web/src/routes/video/[id]/+page.svelte
+++ b/web/src/routes/video/[id]/+page.svelte
@@ -28,6 +28,7 @@
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
 	import { get } from 'svelte/store';
+	import Loading from '$lib/components/ui/Loading.svelte';
 
 	let videoData: VideoResponse | null = null;
 	let loading = false;
@@ -94,9 +95,7 @@
 
 	function parseBeijingTimestamp(value?: string | null): Date | null {
 		if (!value) return null;
-		const match = value.match(
-			/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?$/
-		);
+		const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.\d+)?$/);
 		if (!match) return null;
 		const [, year, month, day, hour, minute, second] = match;
 		return new Date(
@@ -133,7 +132,9 @@
 	function getDanmakuSyncTitle(generation: number, lastSyncedAt?: string | null) {
 		const stageLabel = getDanmakuStageLabel(generation);
 		const description = getDanmakuStageDescription(generation);
-		return lastSyncedAt ? `当前阶段：${stageLabel}。${description}` : `当前阶段：${stageLabel}。${description}`;
+		return lastSyncedAt
+			? `当前阶段：${stageLabel}。${description}`
+			: `当前阶段：${stageLabel}。${description}`;
 	}
 
 	function getDanmakuLastSyncedTitle(value?: string | null) {
@@ -618,9 +619,7 @@
 </svelte:head>
 
 {#if loading}
-	<div class="flex items-center justify-center py-12">
-		<div class="text-muted-foreground">加载中...</div>
-	</div>
+	<Loading />
 {:else if error}
 	<div class="flex items-center justify-center py-12">
 		<div class="space-y-2 text-center">
@@ -762,9 +761,7 @@
 						onclick={handleRefreshVideoDanmaku}
 						disabled={refreshingVideoDanmaku}
 					>
-						<RefreshCwIcon
-							class="mr-2 h-4 w-4 {refreshingVideoDanmaku ? 'animate-spin' : ''}"
-						/>
+						<RefreshCwIcon class="mr-2 h-4 w-4 {refreshingVideoDanmaku ? 'animate-spin' : ''}" />
 						{refreshingVideoDanmaku ? '刷新中...' : '刷新全部弹幕'}
 					</Button>
 				</div>
@@ -803,7 +800,9 @@
 									showProgress={true}
 								/>
 
-								<div class="bg-muted/40 flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
+								<div
+									class="bg-muted/40 flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
+								>
 									<div class="min-w-0">
 										<div
 											class="text-muted-foreground cursor-help text-xs"
@@ -815,7 +814,7 @@
 											弹幕同步
 										</div>
 										<div
-											class="truncate cursor-help text-sm font-medium"
+											class="cursor-help truncate text-sm font-medium"
 											title={getDanmakuSyncTitle(
 												pageInfo.danmaku_sync_generation,
 												pageInfo.danmaku_last_synced_at

--- a/web/src/routes/videos/+page.svelte
+++ b/web/src/routes/videos/+page.svelte
@@ -5,6 +5,7 @@
 	import VideoCard from '$lib/components/video-card.svelte';
 	import Pagination from '$lib/components/pagination.svelte';
 	import SearchBar from '$lib/components/search-bar.svelte';
+	import SectionHeader from '$lib/components/section-header.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
@@ -19,6 +20,8 @@
 	import { VIDEO_SOURCES, type VideoSourceType } from '$lib/consts';
 	import { runRequest } from '$lib/utils/request.js';
 	import { buildVideosRequest } from '$lib/utils/videos.js';
+	import { buildAuthenticatedStreamUrl } from '$lib/utils/live-stream';
+	import { createManagedEventSource } from '$lib/utils/live-event-source';
 	import {
 		appStateStore,
 		resetCurrentPage,
@@ -45,8 +48,7 @@
 	let videoSources: VideoSourcesResponse | null = null;
 	let loading = false;
 	let lastSearch: string | null = null;
-	let videosEventSource: EventSource | null = null;
-	let currentVideosStreamUrl: string | null = null;
+	const videosStream = createManagedEventSource();
 	let liveUpdateStatus: 'idle' | 'connecting' | 'connected' | 'error' = 'idle';
 	let pendingInsertedCount = 0;
 
@@ -79,7 +81,7 @@
 		{ value: '1080', label: '1080p' },
 		{ value: '720', label: '720p' },
 		{ value: '480', label: '480p' },
-		{ value: '360', label: '360p' },
+		{ value: '360', label: '360p' }
 	];
 
 	const RESOLUTION_RANGES: Record<string, { min: number; max: number }> = {
@@ -228,8 +230,26 @@
 		const nextUrl = buildVideosUrl();
 		const currentUrl = `${$page.url.pathname}${$page.url.search}`;
 		if (currentUrl === nextUrl || currentUrl === `${nextUrl}?`) {
-			const { query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight } = $appStateStore;
-			await loadVideos(query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight);
+			const {
+				query,
+				currentPage,
+				videoSource,
+				showFailedOnly,
+				sortBy,
+				sortOrder,
+				minHeight,
+				maxHeight
+			} = $appStateStore;
+			await loadVideos(
+				query,
+				currentPage,
+				videoSource,
+				showFailedOnly,
+				sortBy,
+				sortOrder,
+				minHeight,
+				maxHeight
+			);
 		} else {
 			goto(nextUrl);
 		}
@@ -278,14 +298,15 @@
 		const resolutionRaw = searchParams.get('resolution');
 		const minHeightParsed = minHeightRaw ? Number.parseInt(minHeightRaw, 10) : Number.NaN;
 		const maxHeightParsed = maxHeightRaw ? Number.parseInt(maxHeightRaw, 10) : Number.NaN;
-		const minHeight = Number.isFinite(minHeightParsed) && minHeightParsed >= 0 ? minHeightParsed : null;
-		const maxHeight = Number.isFinite(maxHeightParsed) && maxHeightParsed >= 0 ? maxHeightParsed : null;
+		const minHeight =
+			Number.isFinite(minHeightParsed) && minHeightParsed >= 0 ? minHeightParsed : null;
+		const maxHeight =
+			Number.isFinite(maxHeightParsed) && maxHeightParsed >= 0 ? maxHeightParsed : null;
 		const hasMinMax = Number.isFinite(minHeightParsed) || Number.isFinite(maxHeightParsed);
-		const fallbackRange =
-			!hasMinMax && resolutionRaw ? getResolutionRange(resolutionRaw) : null;
+		const fallbackRange = !hasMinMax && resolutionRaw ? getResolutionRange(resolutionRaw) : null;
 		const normalized = normalizeResolutionRange(
-			hasMinMax ? minHeight : fallbackRange?.min ?? null,
-			hasMinMax ? maxHeight : fallbackRange?.max ?? null
+			hasMinMax ? minHeight : (fallbackRange?.min ?? null),
+			hasMinMax ? maxHeight : (fallbackRange?.max ?? null)
 		);
 
 		return {
@@ -310,10 +331,6 @@
 		minHeight: number | null = null,
 		maxHeight: number | null = null
 	): string | null {
-		if (typeof localStorage === 'undefined') return null;
-		const token = localStorage.getItem('auth_token');
-		if (!token) return null;
-
 		const params = buildVideosRequest({
 			page: pageNum,
 			pageSize,
@@ -326,22 +343,11 @@
 			maxHeight
 		}) as Record<string, string | number | boolean | null | undefined>;
 
-		const searchParams = new URLSearchParams();
-		Object.entries(params).forEach(([key, value]) => {
-			if (value !== undefined && value !== null) {
-				searchParams.append(key, String(value));
-			}
-		});
-		searchParams.append('token', token);
-		return `/api/videos/live?${searchParams.toString()}`;
+		return buildAuthenticatedStreamUrl('/api/videos/live', params);
 	}
 
 	function stopVideosStream() {
-		if (videosEventSource) {
-			videosEventSource.close();
-			videosEventSource = null;
-		}
-		currentVideosStreamUrl = null;
+		videosStream.stop();
 		liveUpdateStatus = 'idle';
 	}
 
@@ -427,41 +433,33 @@
 			maxHeight
 		);
 
-		if (!streamUrl) {
-			stopVideosStream();
-			return;
-		}
-
-		if (videosEventSource && currentVideosStreamUrl === streamUrl) {
-			return;
-		}
-
-		stopVideosStream();
-		currentVideosStreamUrl = streamUrl;
-		liveUpdateStatus = 'connecting';
-
-		const eventSource = new EventSource(streamUrl);
-		videosEventSource = eventSource;
-
-		eventSource.addEventListener('ready', () => {
-			liveUpdateStatus = 'connected';
-		});
-
-		eventSource.addEventListener('videos', (event) => {
-			try {
-				const payload = JSON.parse((event as MessageEvent).data) as VideosResponse;
-				applyLiveVideosUpdate(payload);
-				liveUpdateStatus = 'connected';
-			} catch (error) {
-				console.error('解析视频实时更新失败:', error);
-			}
-		});
-
-		eventSource.onerror = () => {
-			if (videosEventSource === eventSource) {
+		const started = videosStream.start({
+			url: streamUrl,
+			handlers: {
+				ready: () => {
+					liveUpdateStatus = 'connected';
+				},
+				videos: (event) => {
+					try {
+						const payload = JSON.parse(event.data) as VideosResponse;
+						applyLiveVideosUpdate(payload);
+						liveUpdateStatus = 'connected';
+					} catch (error) {
+						console.error('解析视频实时更新失败:', error);
+					}
+				}
+			},
+			onError: () => {
 				liveUpdateStatus = 'error';
+			},
+			onStop: () => {
+				liveUpdateStatus = 'idle';
 			}
-		};
+		});
+
+		if (streamUrl && started) {
+			liveUpdateStatus = 'connecting';
+		}
 	}
 
 	async function handlePendingInsertedClick() {
@@ -506,7 +504,16 @@
 			pageSize
 		);
 		pendingInsertedCount = 0;
-		startVideosStream(query, pageNum, filter, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight);
+		startVideosStream(
+			query,
+			pageNum,
+			filter,
+			showFailedOnly,
+			sortBy,
+			sortOrder,
+			minHeight,
+			maxHeight
+		);
 	}
 
 	async function loadVideoSources() {
@@ -534,7 +541,16 @@
 			minHeight,
 			maxHeight
 		} = getApiParams(searchParams);
-		setAll(query, pageNum, videoSource, showFailedOnlyParam, sortBy, sortOrder, minHeight, maxHeight);
+		setAll(
+			query,
+			pageNum,
+			videoSource,
+			showFailedOnlyParam,
+			sortBy,
+			sortOrder,
+			minHeight,
+			maxHeight
+		);
 
 		// 同步筛选状态
 		if (videoSource) {
@@ -549,7 +565,16 @@
 		currentSortOrder = sortOrder;
 		selectedResolution = getResolutionKey(minHeight, maxHeight);
 
-		loadVideos(query, pageNum, videoSource, showFailedOnlyParam, sortBy, sortOrder, minHeight, maxHeight);
+		loadVideos(
+			query,
+			pageNum,
+			videoSource,
+			showFailedOnlyParam,
+			sortBy,
+			sortOrder,
+			minHeight,
+			maxHeight
+		);
 	}
 
 	async function handleResetVideo(video: VideoInfo, forceReset: boolean) {
@@ -560,9 +585,26 @@
 				toast.success('重置成功', {
 					description: `视频「${video.name}」已重置`
 				});
-				const { query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight } =
-					$appStateStore;
-				await loadVideos(query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight);
+				const {
+					query,
+					currentPage,
+					videoSource,
+					showFailedOnly,
+					sortBy,
+					sortOrder,
+					minHeight,
+					maxHeight
+				} = $appStateStore;
+				await loadVideos(
+					query,
+					currentPage,
+					videoSource,
+					showFailedOnly,
+					sortBy,
+					sortOrder,
+					minHeight,
+					maxHeight
+				);
 			} else {
 				toast.info('重置无效', {
 					description: `视频「${video.name}」没有失败的状态，无需重置`
@@ -580,7 +622,13 @@
 		resettingAll = true;
 		try {
 			let result;
-			const { videoSource, query: queryWord, showFailedOnly, minHeight, maxHeight } = $appStateStore;
+			const {
+				videoSource,
+				query: queryWord,
+				showFailedOnly,
+				minHeight,
+				maxHeight
+			} = $appStateStore;
 
 			// 让“批量重置”遵循当前筛选（视频源 / 搜索关键词 / 失败筛选 / 分辨率筛选）
 			const filterParams = buildVideosRequest({
@@ -846,9 +894,26 @@
 				}
 
 				// 重新加载视频列表
-				const { query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight } =
-					$appStateStore;
-				await loadVideos(query, currentPage, videoSource, showFailedOnly, sortBy, sortOrder, minHeight, maxHeight);
+				const {
+					query,
+					currentPage,
+					videoSource,
+					showFailedOnly,
+					sortBy,
+					sortOrder,
+					minHeight,
+					maxHeight
+				} = $appStateStore;
+				await loadVideos(
+					query,
+					currentPage,
+					videoSource,
+					showFailedOnly,
+					sortBy,
+					sortOrder,
+					minHeight,
+					maxHeight
+				);
 
 				// 清空选择
 				clearSelection();
@@ -892,6 +957,14 @@
 </svelte:head>
 
 <div class="space-y-6">
+	<SectionHeader
+		as="h1"
+		title="视频管理"
+		description="搜索、筛选并批量管理已同步的视频列表。"
+		titleClass="text-2xl font-bold"
+		descriptionClass="text-muted-foreground mt-1 text-sm"
+	/>
+
 	<!-- 搜索和筛选栏 -->
 	<div class="flex flex-col gap-4">
 		<!-- 搜索栏 -->
@@ -938,7 +1011,7 @@
 					<!-- 显示数量设置 -->
 					<div class="grid grid-cols-2 gap-2 sm:flex sm:items-center sm:gap-2">
 						<label class="flex items-center gap-2">
-							<span class="text-muted-foreground whitespace-nowrap text-sm">每页</span>
+							<span class="text-muted-foreground text-sm whitespace-nowrap">每页</span>
 							<input
 								class="border-input bg-background ring-offset-background focus:ring-ring h-9 w-full min-w-0 rounded-md border px-2 py-1 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none sm:w-24"
 								type="number"
@@ -949,7 +1022,7 @@
 							/>
 						</label>
 						<label class="flex items-center gap-2">
-							<span class="text-muted-foreground whitespace-nowrap text-sm">每行</span>
+							<span class="text-muted-foreground text-sm whitespace-nowrap">每行</span>
 							<input
 								class="border-input bg-background ring-offset-background focus:ring-ring h-9 w-full min-w-0 rounded-md border px-2 py-1 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none sm:w-24"
 								type="number"
@@ -1054,7 +1127,6 @@
 					{/if}
 				</div>
 			</div>
-
 		</div>
 	{/if}
 
@@ -1117,7 +1189,6 @@
 					</select>
 				</div>
 			</div>
-
 		</div>
 	{/if}
 
@@ -1144,9 +1215,9 @@
 				{/if}
 			{/if}
 
-
 			{#if selectedResolution}
-				<Badge variant="secondary" class="flex items-center gap-1">分辨率 {getResolutionLabel(selectedResolution)}
+				<Badge variant="secondary" class="flex items-center gap-1"
+					>分辨率 {getResolutionLabel(selectedResolution)}
 					<button
 						onclick={() => handleResolutionChange('')}
 						class="hover:bg-muted-foreground/20 ml-1 rounded"
@@ -1271,7 +1342,6 @@
 				<div class="text-muted-foreground">暂无视频数据</div>
 				<p class="text-muted-foreground text-sm">尝试调整搜索条件或添加视频源</p>
 			</div>
-
 		</div>
 	{/if}
 </div>

--- a/web/src/routes/videos/+page.svelte
+++ b/web/src/routes/videos/+page.svelte
@@ -6,6 +6,9 @@
 	import Pagination from '$lib/components/pagination.svelte';
 	import SearchBar from '$lib/components/search-bar.svelte';
 	import SectionHeader from '$lib/components/section-header.svelte';
+	import Loading from '$lib/components/ui/Loading.svelte';
+	import SelectAllButton from '$lib/components/select-all-button.svelte';
+	import EmptyState from '$lib/components/empty-state.svelte';
 	import { Button } from '$lib/components/ui/button/index.js';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
@@ -1112,7 +1115,7 @@
 				</div>
 				<div class="flex gap-2">
 					{#if videosData?.videos && selectedVideos.size < videosData.videos.length}
-						<Button variant="outline" size="sm" onclick={selectAllVideos}>全选</Button>
+						<SelectAllButton onclick={selectAllVideos} className="text-sm" />
 					{/if}
 					{#if selectedVideos.size > 0}
 						<Button variant="outline" size="sm" onclick={clearSelection}>取消选中</Button>
@@ -1307,9 +1310,7 @@
 
 	<!-- 视频卡片网格 -->
 	{#if loading}
-		<div class="flex items-center justify-center py-16">
-			<div class="text-muted-foreground">加载中...</div>
-		</div>
+		<Loading size="lg" />
 	{:else if videosData?.videos.length}
 		<div
 			class="grid gap-4 sm:grid-cols-2 md:grid-cols-[repeat(var(--videos-grid-cols),minmax(0,1fr))]"
@@ -1337,12 +1338,7 @@
 			/>
 		{/if}
 	{:else}
-		<div class="flex items-center justify-center py-16">
-			<div class="space-y-2 text-center">
-				<div class="text-muted-foreground">暂无视频数据</div>
-				<p class="text-muted-foreground text-sm">尝试调整搜索条件或添加视频源</p>
-			</div>
-		</div>
+		<EmptyState title="暂无视频数据" description="尝试调整搜索条件或添加视频源" class="py-16" />
 	{/if}
 </div>
 


### PR DESCRIPTION
## 变更说明
- 继续完善前端 UI 复用，统一页面级/局部 loading 组件用法
- 新增 `select-all-button.svelte`，收敛多处批量全选按钮
- 将多处空态进一步统一到 `EmptyState`
- 更新前端复用记录文档

## 已验证
- `npx -y -p node@20 -c "node --version && npm run check"`
- `npx -y -p node@20 -c "node --version && npm run build"`

## 备注
- 本次继续沿用现有 PR：#140
