### PR TITLE
修复合集封面回查接口

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -3751,7 +3751,7 @@ pub async fn add_video_source_internal(
                         })
                         .unwrap_or_default();
                     let client = crate::bilibili::BiliClient::new(cookie);
-                    match get_collection_cover_from_api(up_id, s_id, &client).await {
+                    match get_collection_cover_from_api(up_id, s_id, collection_type, &client).await {
                         Ok(cover) => {
                             info!("成功从API获取合集「{}」封面: {}", collection_name, cover);
                             Some(cover)
@@ -16197,37 +16197,23 @@ fn extract_bangumi_season_title(full_title: &str) -> String {
 async fn get_collection_cover_from_api(
     up_id: i64,
     collection_id: i64,
+    collection_type: i32,
     client: &crate::bilibili::BiliClient,
 ) -> Result<String, anyhow::Error> {
-    // 分页获取所有合集，避免遗漏
-    let mut page = 1;
-    loop {
-        let collections_response = client.get_user_collections(up_id, page, 50).await?;
+    let collection = crate::bilibili::CollectionItem {
+        mid: up_id.to_string(),
+        sid: collection_id.to_string(),
+        collection_type: if collection_type == 1 {
+            crate::bilibili::CollectionType::Series
+        } else {
+            crate::bilibili::CollectionType::Season
+        },
+    };
 
-        // 查找目标合集
-        for collection in &collections_response.collections {
-            if collection.sid.parse::<i64>().unwrap_or(0) == collection_id {
-                if !collection.cover.is_empty() {
-                    return Ok(collection.cover.clone());
-                } else {
-                    return Err(anyhow!("合集封面URL为空"));
-                }
-            }
-        }
-
-        // 检查是否还有更多页
-        if collections_response.collections.len() < 50 {
-            break; // 已经是最后一页
-        }
-        page += 1;
-
-        // 安全限制，避免无限循环
-        if page > 20 {
-            return Err(anyhow!("搜索合集时达到最大页数限制 (20页)"));
-        }
-    }
-
-    Err(anyhow!("未找到合集ID {} (UP主: {})", collection_id, up_id))
+    crate::bilibili::Collection::new(client, &collection)
+        .get_cover_url()
+        .await
+        .with_context(|| format!("获取合集 {} 封面失败 (UP主: {})", collection_id, up_id))
 }
 
 /// 处理番剧合并到现有源的逻辑

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -16200,20 +16200,26 @@ async fn get_collection_cover_from_api(
     collection_type: i32,
     client: &crate::bilibili::BiliClient,
 ) -> Result<String, anyhow::Error> {
-    let collection = crate::bilibili::CollectionItem {
-        mid: up_id.to_string(),
-        sid: collection_id.to_string(),
-        collection_type: if collection_type == 1 {
-            crate::bilibili::CollectionType::Series
-        } else {
-            crate::bilibili::CollectionType::Season
-        },
-    };
-
-    crate::bilibili::Collection::new(client, &collection)
-        .get_cover_url()
+    let expected_collection_type = if collection_type == 1 { "series" } else { "season" };
+    let collections_response = client
+        .get_user_collections(up_id, 1, 30)
         .await
-        .with_context(|| format!("获取合集 {} 封面失败 (UP主: {})", collection_id, up_id))
+        .with_context(|| format!("获取UP主 {} 的合集列表失败", up_id))?;
+    let collection = collections_response
+        .collections
+        .iter()
+        .find(|item| {
+            item.collection_type == expected_collection_type
+                && item.sid.parse::<i64>().ok() == Some(collection_id)
+        })
+        .ok_or_else(|| anyhow!("未在合集列表中找到目标合集"))?;
+    let cover_url = collection.cover.trim();
+    if cover_url.is_empty() {
+        Err(anyhow!("合集封面URL为空"))
+    } else {
+        Ok(cover_url.to_string())
+    }
+    .with_context(|| format!("获取合集 {} 封面失败 (UP主: {})", collection_id, up_id))
 }
 
 /// 处理番剧合并到现有源的逻辑

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -684,91 +684,61 @@ impl BiliClient {
         let mut total_count = 0u32;
 
         loop {
-            let mut retry_count = 0;
-            let max_retries = 2;
-
-            // 添加重试机制获取当前页数据
-            let seasons_response = loop {
-                let mid_str = mid.to_string();
-                let page_num_str = current_page.to_string();
-                let page_size_str = page_size.to_string();
-                let web_location = "333.1387".to_string();
-                match self
-                    .request(Method::GET, seasons_url)
-                    .await
-                    .query(&[
-                        ("mid", &mid_str),
-                        ("page_num", &page_num_str),
-                        ("page_size", &page_size_str),
-                        ("web_location", &web_location),
-                    ])
-                    .send()
-                    .await
-                {
-                    Ok(response) => match response.error_for_status() {
-                        Ok(response) => match response.json::<Value>().await {
-                            Ok(json) => match json.validate() {
-                                Ok(validated) => break validated,
-                                Err(e) => {
-                                    if emit_warning {
-                                        warn!("UP主 {} 合集响应验证失败: {}", mid, e);
-                                    } else {
-                                        info!("UP主 {} 合集响应验证失败: {}", mid, e);
-                                    }
-                                    if retry_count >= max_retries {
-                                        return Err(e.context("合集响应验证失败"));
-                                    }
-                                }
-                            },
+            let mid_str = mid.to_string();
+            let page_num_str = current_page.to_string();
+            let page_size_str = page_size.to_string();
+            let web_location = "333.1387".to_string();
+            let seasons_response = match self
+                .request(Method::GET, seasons_url)
+                .await
+                .query(&[
+                    ("mid", &mid_str),
+                    ("page_num", &page_num_str),
+                    ("page_size", &page_size_str),
+                    ("web_location", &web_location),
+                ])
+                .send()
+                .await
+            {
+                Ok(response) => match response.error_for_status() {
+                    Ok(response) => match response.json::<Value>().await {
+                        Ok(json) => match json.validate() {
+                            Ok(validated) => validated,
                             Err(e) => {
                                 if emit_warning {
-                                    warn!("UP主 {} 合集JSON解析失败: {}", mid, e);
+                                    warn!("UP主 {} 合集响应验证失败: {}", mid, e);
                                 } else {
-                                    info!("UP主 {} 合集JSON解析失败: {}", mid, e);
+                                    info!("UP主 {} 合集响应验证失败: {}", mid, e);
                                 }
-                                if retry_count >= max_retries {
-                                    return Err(anyhow!("解析合集响应JSON失败: {}", e));
-                                }
+                                return Err(e.context("合集响应验证失败"));
                             }
                         },
                         Err(e) => {
                             if emit_warning {
-                                warn!("UP主 {} 合集请求状态错误: {}", mid, e);
+                                warn!("UP主 {} 合集JSON解析失败: {}", mid, e);
                             } else {
-                                info!("UP主 {} 合集请求状态错误: {}", mid, e);
+                                info!("UP主 {} 合集JSON解析失败: {}", mid, e);
                             }
-                            if retry_count >= max_retries {
-                                return Err(anyhow!("合集请求返回错误状态: {}", e));
-                            }
+                            return Err(anyhow!("解析合集响应JSON失败: {}", e));
                         }
                     },
                     Err(e) => {
                         if emit_warning {
-                            warn!(
-                                "UP主 {} 合集请求失败 (重试 {}/{}): {}",
-                                mid,
-                                retry_count + 1,
-                                max_retries + 1,
-                                e
-                            );
+                            warn!("UP主 {} 合集请求状态错误: {}", mid, e);
                         } else {
-                            info!(
-                                "UP主 {} 合集请求失败 (重试 {}/{}): {}",
-                                mid,
-                                retry_count + 1,
-                                max_retries + 1,
-                                e
-                            );
+                            info!("UP主 {} 合集请求状态错误: {}", mid, e);
                         }
-                        if retry_count >= max_retries {
-                            return Err(anyhow!("发送合集请求失败: {}", e));
-                        }
+                        return Err(anyhow!("合集请求返回错误状态: {}", e));
                     }
+                },
+                Err(e) => {
+                    if emit_warning {
+                        warn!("UP主 {} 合集请求失败: {}", mid, e);
+                    } else {
+                        info!("UP主 {} 合集请求失败: {}", mid, e);
+                    }
+                    return Err(anyhow!("发送合集请求失败: {}", e));
                 }
-
-                retry_count += 1;
-                // 重试前等待
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
             };
 
             // 检查响应是否包含items_lists字段

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -630,6 +630,9 @@ impl BiliClient {
         page_size: u32,
     ) -> Result<crate::api::response::UserCollectionsResponse> {
         use serde_json::Value;
+        // 该接口在部分特殊账号上对较大的 page_size 会直接返回 -400。
+        // 这里统一收紧到 10，换取稳定性；调用方本身会聚合所有页面，不依赖单页大小语义。
+        let page_size = page_size.clamp(1, 10);
 
         // 同时获取合集(seasons)和系列(series)
         let mut all_collections = Vec::new();

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -629,10 +629,51 @@ impl BiliClient {
         _page: u32,
         page_size: u32,
     ) -> Result<crate::api::response::UserCollectionsResponse> {
+        let normalized_page_size = page_size.clamp(1, 30);
+        let mut page_size_candidates = vec![normalized_page_size];
+        for fallback_page_size in [20, 10] {
+            if normalized_page_size > fallback_page_size {
+                page_size_candidates.push(fallback_page_size);
+            }
+        }
+
+        let mut last_err = None;
+        for (index, candidate_page_size) in page_size_candidates.iter().copied().enumerate() {
+            let is_final_candidate = index + 1 == page_size_candidates.len();
+            match self
+                .get_user_collections_with_page_size(mid, candidate_page_size, is_final_candidate)
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    last_err = Some(err);
+                    if let Some(next_page_size) = page_size_candidates.get(index + 1) {
+                        info!(
+                            "UP主 {} 使用 page_size={} 获取合集失败，将降级重试为 page_size={}",
+                            mid, candidate_page_size, next_page_size
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Some(ref err) = last_err {
+            warn!(
+                "UP主 {} 获取合集失败，已依次尝试 page_size={:?}: {}",
+                mid, page_size_candidates, err
+            );
+        }
+
+        Err(last_err.unwrap_or_else(|| anyhow!("获取合集失败")))
+    }
+
+    async fn get_user_collections_with_page_size(
+        &self,
+        mid: i64,
+        page_size: u32,
+        emit_warning: bool,
+    ) -> Result<crate::api::response::UserCollectionsResponse> {
         use serde_json::Value;
-        // 该接口在部分特殊账号上对较大的 page_size 会直接返回 -400。
-        // 这里统一收紧到 10，换取稳定性；调用方本身会聚合所有页面，不依赖单页大小语义。
-        let page_size = page_size.clamp(1, 10);
 
         // 同时获取合集(seasons)和系列(series)
         let mut all_collections = Vec::new();
@@ -669,34 +710,56 @@ impl BiliClient {
                             Ok(json) => match json.validate() {
                                 Ok(validated) => break validated,
                                 Err(e) => {
-                                    warn!("UP主 {} 合集响应验证失败: {}", mid, e);
+                                    if emit_warning {
+                                        warn!("UP主 {} 合集响应验证失败: {}", mid, e);
+                                    } else {
+                                        info!("UP主 {} 合集响应验证失败: {}", mid, e);
+                                    }
                                     if retry_count >= max_retries {
                                         return Err(e.context("合集响应验证失败"));
                                     }
                                 }
                             },
                             Err(e) => {
-                                warn!("UP主 {} 合集JSON解析失败: {}", mid, e);
+                                if emit_warning {
+                                    warn!("UP主 {} 合集JSON解析失败: {}", mid, e);
+                                } else {
+                                    info!("UP主 {} 合集JSON解析失败: {}", mid, e);
+                                }
                                 if retry_count >= max_retries {
                                     return Err(anyhow!("解析合集响应JSON失败: {}", e));
                                 }
                             }
                         },
                         Err(e) => {
-                            warn!("UP主 {} 合集请求状态错误: {}", mid, e);
+                            if emit_warning {
+                                warn!("UP主 {} 合集请求状态错误: {}", mid, e);
+                            } else {
+                                info!("UP主 {} 合集请求状态错误: {}", mid, e);
+                            }
                             if retry_count >= max_retries {
                                 return Err(anyhow!("合集请求返回错误状态: {}", e));
                             }
                         }
                     },
                     Err(e) => {
-                        warn!(
-                            "UP主 {} 合集请求失败 (重试 {}/{}): {}",
-                            mid,
-                            retry_count + 1,
-                            max_retries + 1,
-                            e
-                        );
+                        if emit_warning {
+                            warn!(
+                                "UP主 {} 合集请求失败 (重试 {}/{}): {}",
+                                mid,
+                                retry_count + 1,
+                                max_retries + 1,
+                                e
+                            );
+                        } else {
+                            info!(
+                                "UP主 {} 合集请求失败 (重试 {}/{}): {}",
+                                mid,
+                                retry_count + 1,
+                                max_retries + 1,
+                                e
+                            );
+                        }
                         if retry_count >= max_retries {
                             return Err(anyhow!("发送合集请求失败: {}", e));
                         }

--- a/crates/bili_sync/src/bilibili/collection.rs
+++ b/crates/bili_sync/src/bilibili/collection.rs
@@ -123,6 +123,21 @@ impl<'a> Collection<'a> {
         Self { client, collection }
     }
 
+    pub async fn get_cover_url(&self) -> Result<String> {
+        let meta = match self.collection.collection_type {
+            CollectionType::Season => self.get_videos(1).await?["data"]["meta"].clone(),
+            CollectionType::Series => self.get_series_info().await?["data"]["meta"].clone(),
+        };
+
+        meta.get("cover")
+            .and_then(|v| v.as_str())
+            .or_else(|| meta.get("square_cover").and_then(|v| v.as_str()))
+            .or_else(|| meta.get("horizontal_cover").and_then(|v| v.as_str()))
+            .filter(|cover| !cover.trim().is_empty())
+            .map(|cover| cover.to_string())
+            .ok_or_else(|| anyhow!("合集封面URL为空"))
+    }
+
     pub async fn get_info(&self) -> Result<CollectionInfo> {
         let meta = match self.collection.collection_type {
             // 没有找到专门获取 Season 信息的接口，所以直接获取第一页，从里面取 meta 信息

--- a/crates/bili_sync/src/bilibili/collection.rs
+++ b/crates/bili_sync/src/bilibili/collection.rs
@@ -123,21 +123,6 @@ impl<'a> Collection<'a> {
         Self { client, collection }
     }
 
-    pub async fn get_cover_url(&self) -> Result<String> {
-        let meta = match self.collection.collection_type {
-            CollectionType::Season => self.get_videos(1).await?["data"]["meta"].clone(),
-            CollectionType::Series => self.get_series_info().await?["data"]["meta"].clone(),
-        };
-
-        meta.get("cover")
-            .and_then(|v| v.as_str())
-            .or_else(|| meta.get("square_cover").and_then(|v| v.as_str()))
-            .or_else(|| meta.get("horizontal_cover").and_then(|v| v.as_str()))
-            .filter(|cover| !cover.trim().is_empty())
-            .map(|cover| cover.to_string())
-            .ok_or_else(|| anyhow!("合集封面URL为空"))
-    }
-
     pub async fn get_info(&self) -> Result<CollectionInfo> {
         let meta = match self.collection.collection_type {
             // 没有找到专门获取 Season 信息的接口，所以直接获取第一页，从里面取 meta 信息

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -109,20 +109,26 @@ async fn fetch_collection_cover_url(
     collection_sid: i64,
     collection_type: i32,
 ) -> Result<String> {
-    let collection = crate::bilibili::CollectionItem {
-        mid: up_mid.to_string(),
-        sid: collection_sid.to_string(),
-        collection_type: if collection_type == 1 {
-            crate::bilibili::CollectionType::Series
-        } else {
-            crate::bilibili::CollectionType::Season
-        },
-    };
-
-    crate::bilibili::Collection::new(bili_client, &collection)
-        .get_cover_url()
+    let expected_collection_type = if collection_type == 1 { "series" } else { "season" };
+    let collections_response = bili_client
+        .get_user_collections(up_mid, 1, 30)
         .await
-        .with_context(|| format!("直连获取合集封面失败: sid={}, up_mid={}", collection_sid, up_mid))
+        .with_context(|| format!("获取合集列表失败: up_mid={}", up_mid))?;
+    let collection = collections_response
+        .collections
+        .iter()
+        .find(|item| {
+            item.collection_type == expected_collection_type
+                && item.sid.parse::<i64>().ok() == Some(collection_sid)
+        })
+        .ok_or_else(|| anyhow!("未在合集列表中找到目标合集"))?;
+    let cover_url = collection.cover.trim();
+    if cover_url.is_empty() {
+        Err(anyhow!("合集封面URL为空"))
+    } else {
+        Ok(cover_url.to_string())
+    }
+    .with_context(|| format!("从合集列表获取封面失败: sid={}, up_mid={}", collection_sid, up_mid))
 }
 
 fn get_root_alias_asset_write_lock(root_dir: &Path) -> Arc<TokioMutex<()>> {

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -103,6 +103,28 @@ fn get_submission_upper_intro_load_lock(upper_id: i64) -> Arc<TokioMutex<()>> {
         .clone()
 }
 
+async fn fetch_collection_cover_url(
+    bili_client: &crate::bilibili::BiliClient,
+    up_mid: i64,
+    collection_sid: i64,
+    collection_type: i32,
+) -> Result<String> {
+    let collection = crate::bilibili::CollectionItem {
+        mid: up_mid.to_string(),
+        sid: collection_sid.to_string(),
+        collection_type: if collection_type == 1 {
+            crate::bilibili::CollectionType::Series
+        } else {
+            crate::bilibili::CollectionType::Season
+        },
+    };
+
+    crate::bilibili::Collection::new(bili_client, &collection)
+        .get_cover_url()
+        .await
+        .with_context(|| format!("直连获取合集封面失败: sid={}, up_mid={}", collection_sid, up_mid))
+}
+
 fn get_root_alias_asset_write_lock(root_dir: &Path) -> Arc<TokioMutex<()>> {
     let key = root_dir.to_string_lossy().to_string();
     let mut locks = ROOT_ALIAS_ASSET_WRITE_LOCKS.lock().unwrap_or_else(|e| e.into_inner());
@@ -4313,39 +4335,25 @@ pub async fn download_video_pages(
                             info!("合集「{}」使用数据库保存的封面: {}", fresh_collection.name, cover_url);
                             Some(cover_url.clone())
                         }
-                        _ => match bili_client.get_user_collections(fresh_collection.m_id, 1, 50).await {
-                            Ok(collections_response) => {
-                                let fetched_cover = collections_response
-                                    .collections
-                                    .iter()
-                                    .find(|item| item.sid.parse::<i64>().ok() == Some(fresh_collection.s_id))
-                                    .and_then(|item| {
-                                        let cover = item.cover.trim();
-                                        if cover.is_empty() {
-                                            None
-                                        } else {
-                                            Some(cover.to_string())
-                                        }
-                                    });
-
-                                if let Some(ref cover_url) = fetched_cover {
-                                    info!("合集「{}」运行时回查封面成功: {}", fresh_collection.name, cover_url);
-                                    let mut active_model: collection::ActiveModel = fresh_collection.clone().into();
-                                    active_model.cover = Set(Some(cover_url.clone()));
-                                    if let Err(err) = active_model.update(connection).await {
-                                        warn!(
-                                                "回写合集封面到数据库失败（将继续使用本次结果）: collection_id={}, sid={}, err={}",
-                                                collection_source.id, collection_source.s_id, err
-                                            );
-                                    }
-                                } else {
-                                    info!(
-                                            "合集「{}」数据库和API中都没有稳定封面；若由非首集补封面，将不再回退为当前分集封面",
-                                            fresh_collection.name
+                        _ => match fetch_collection_cover_url(
+                            bili_client,
+                            fresh_collection.m_id,
+                            fresh_collection.s_id,
+                            fresh_collection.r#type,
+                        )
+                        .await
+                        {
+                            Ok(cover_url) => {
+                                info!("合集「{}」运行时回查封面成功: {}", fresh_collection.name, cover_url);
+                                let mut active_model: collection::ActiveModel = fresh_collection.clone().into();
+                                active_model.cover = Set(Some(cover_url.clone()));
+                                if let Err(err) = active_model.update(connection).await {
+                                    warn!(
+                                            "回写合集封面到数据库失败（将继续使用本次结果）: collection_id={}, sid={}, err={}",
+                                            collection_source.id, collection_source.s_id, err
                                         );
                                 }
-
-                                fetched_cover
+                                Some(cover_url)
                             }
                             Err(err) => {
                                 warn!(


### PR DESCRIPTION
## Summary
- 修复合集封面回查逻辑，不再先枚举 UP 主全部合集后再匹配目标合集，而是直接按当前合集类型和 sid 拉取具体合集元数据获取封面
- 为 `seasons_series_list` 增加 `page_size` 上限保护，统一收紧到 10，避免部分特殊账号在较大分页参数下直接返回 `-400`
- 让添加源时的合集封面补全与下载阶段的运行时封面回查走同一条稳定路径

## Validation
- `cargo check -p bili_sync`

## Notes
- 根因是部分特殊 `mid` 在 `x/polymer/web-space/seasons_series_list` 上对较大的 `page_size` 不兼容，会返回 `-400 请求错误`
- 具体合集接口 `x/polymer/web-space/seasons_archives_list` 对同一合集可正常返回封面元数据，因此更适合作为封面回查来源