### PR TITLE
添加 NFO genre 标签开关

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -8225,6 +8225,7 @@ pub async fn get_config() -> Result<ApiResponse<crate::api::response::ConfigResp
         time_format: config.time_format.clone(),
         interval: config.interval,
         nfo_time_type: nfo_time_type.to_string(),
+        nfo_include_genre: config.nfo_config.include_genre,
         parallel_download_enabled: config.concurrent_limit.parallel_download.enabled,
         parallel_download_threads: config.concurrent_limit.parallel_download.threads,
         parallel_download_use_aria2: config.concurrent_limit.parallel_download.use_aria2,
@@ -8402,6 +8403,7 @@ pub async fn update_config(
             time_format: params.time_format.clone(),
             interval: params.interval,
             nfo_time_type: params.nfo_time_type.clone(),
+            nfo_include_genre: params.nfo_include_genre,
             parallel_download_enabled: params.parallel_download_enabled,
             parallel_download_threads: params.parallel_download_threads,
             parallel_download_use_aria2: params.parallel_download_use_aria2,
@@ -8690,6 +8692,7 @@ pub async fn update_config_internal(
 
     // 记录原始的NFO时间类型，用于比较是否真正发生了变化
     let original_nfo_time_type = config.nfo_time_type.clone();
+    let original_nfo_include_genre = config.nfo_config.include_genre;
 
     // 记录原始的命名相关配置，用于比较是否真正发生了变化
     let original_collection_folder_mode = config.collection_folder_mode.clone();
@@ -8858,6 +8861,13 @@ pub async fn update_config_internal(
         if original_nfo_time_type != new_nfo_time_type {
             config.nfo_time_type = new_nfo_time_type;
             updated_fields.push("nfo_time_type");
+        }
+    }
+
+    if let Some(nfo_include_genre) = params.nfo_include_genre {
+        if original_nfo_include_genre != nfo_include_genre {
+            config.nfo_config.include_genre = nfo_include_genre;
+            updated_fields.push("nfo_include_genre");
         }
     }
 
@@ -9829,6 +9839,11 @@ pub async fn update_config_internal(
                         .update_config_item("nfo_time_type", serde_json::to_value(&config.nfo_time_type)?)
                         .await
                 }
+                "nfo_include_genre" => {
+                    manager
+                        .update_config_item("nfo_config", serde_json::to_value(&config.nfo_config)?)
+                        .await
+                }
                 "upper_path" => {
                     manager
                         .update_config_item("upper_path", serde_json::to_value(&config.upper_path)?)
@@ -10161,7 +10176,7 @@ pub async fn update_config_internal(
     }
 
     // 检查是否需要重置NFO任务状态
-    let should_reset_nfo = updated_fields.contains(&"nfo_time_type");
+    let should_reset_nfo = updated_fields.contains(&"nfo_time_type") || updated_fields.contains(&"nfo_include_genre");
     let mut resetted_nfo_videos_count = 0;
     let mut resetted_nfo_pages_count = 0;
 

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -195,6 +195,8 @@ pub struct UpdateConfigRequest {
     pub interval: Option<u64>,
     // NFO时间类型
     pub nfo_time_type: Option<String>,
+    // NFO是否写入genre标签
+    pub nfo_include_genre: Option<bool>,
     // 多线程下载配置
     pub parallel_download_enabled: Option<bool>,
     pub parallel_download_threads: Option<usize>,

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -446,6 +446,7 @@ pub struct ConfigResponse {
     pub time_format: String,
     pub interval: u64,
     pub nfo_time_type: String,
+    pub nfo_include_genre: bool,
     // 多线程下载配置
     pub parallel_download_enabled: bool,
     pub parallel_download_threads: usize,

--- a/crates/bili_sync/src/config/item.rs
+++ b/crates/bili_sync/src/config/item.rs
@@ -44,6 +44,9 @@ pub struct NFOConfig {
     /// 是否生成 NFO 文件
     #[serde(default = "default_nfo_enabled")]
     pub enabled: bool,
+    /// 是否写入 <genre> 标签
+    #[serde(default = "default_include_genre")]
+    pub include_genre: bool,
     /// NFO 文件格式类型
     #[serde(default)]
     pub format_type: NFOFormatType,
@@ -80,6 +83,10 @@ fn default_nfo_enabled() -> bool {
     true
 }
 
+fn default_include_genre() -> bool {
+    true
+}
+
 fn default_include_bilibili_info() -> bool {
     true
 }
@@ -112,6 +119,7 @@ impl Default for NFOConfig {
     fn default() -> Self {
         Self {
             enabled: default_nfo_enabled(),
+            include_genre: default_include_genre(),
             format_type: NFOFormatType::default(),
             time_type: NFOTimeType::default(),
             include_bilibili_info: default_include_bilibili_info(),

--- a/crates/bili_sync/src/task/mod.rs
+++ b/crates/bili_sync/src/task/mod.rs
@@ -69,6 +69,7 @@ pub struct UpdateConfigTask {
     pub time_format: Option<String>,
     pub interval: Option<u64>,
     pub nfo_time_type: Option<String>,
+    pub nfo_include_genre: Option<bool>,
     pub parallel_download_enabled: Option<bool>,
     pub parallel_download_threads: Option<usize>,
     pub parallel_download_use_aria2: Option<bool>,
@@ -1588,9 +1589,15 @@ impl RefreshDanmakuTaskQueue {
 
         while let Some(task) = self.dequeue_task().await {
             let result = match (task.video_id, task.page_id) {
-                (Some(video_id), None) => crate::workflow_danmaku::schedule_video_danmaku_refresh(db.as_ref(), video_id).await,
-                (None, Some(page_id)) => crate::workflow_danmaku::schedule_page_danmaku_refresh(db.as_ref(), page_id).await,
-                _ => Err(anyhow::anyhow!("无效的弹幕刷新任务：必须且只能指定 video_id 或 page_id")),
+                (Some(video_id), None) => {
+                    crate::workflow_danmaku::schedule_video_danmaku_refresh(db.as_ref(), video_id).await
+                }
+                (None, Some(page_id)) => {
+                    crate::workflow_danmaku::schedule_page_danmaku_refresh(db.as_ref(), page_id).await
+                }
+                _ => Err(anyhow::anyhow!(
+                    "无效的弹幕刷新任务：必须且只能指定 video_id 或 page_id"
+                )),
             };
 
             match result {
@@ -2295,6 +2302,7 @@ impl ConfigTaskQueue {
                 time_format: task.time_format.clone(),
                 interval: task.interval,
                 nfo_time_type: task.nfo_time_type.clone(),
+                nfo_include_genre: task.nfo_include_genre,
                 parallel_download_enabled: task.parallel_download_enabled,
                 parallel_download_threads: task.parallel_download_threads,
                 parallel_download_use_aria2: task.parallel_download_use_aria2,

--- a/crates/bili_sync/src/utils/nfo.rs
+++ b/crates/bili_sync/src/utils/nfo.rs
@@ -102,19 +102,19 @@ pub struct Episode<'a> {
     pub user_rating: Option<f32>,
     pub director: Option<&'a str>,
     pub credits: Option<&'a str>,
-    pub bvid: &'a str,               // B站视频ID
-    pub category: i32,               // 视频分类（用于番剧检测）
-    pub mpaa: Option<&'a str>,       // 年龄分级
-    pub country: Option<&'a str>,    // 国家
-    pub studio: Option<&'a str>,     // 制作工作室
-    pub genres: Option<Vec<String>>, // 类型标签
-    pub upper_id: i64,               // UP主UID
-    pub upper_name: &'a str,         // UP主名称
-    pub actors_info: Option<String>, // 演员信息字符串
+    pub bvid: &'a str,                             // B站视频ID
+    pub category: i32,                             // 视频分类（用于番剧检测）
+    pub mpaa: Option<&'a str>,                     // 年龄分级
+    pub country: Option<&'a str>,                  // 国家
+    pub studio: Option<&'a str>,                   // 制作工作室
+    pub genres: Option<Vec<String>>,               // 类型标签
+    pub upper_id: i64,                             // UP主UID
+    pub upper_name: &'a str,                       // UP主名称
+    pub actors_info: Option<String>,               // 演员信息字符串
     pub staff_info: Option<&'a serde_json::Value>, // 联合投稿成员信息
-    pub thumb_url: Option<&'a str>,  // 缩略图URL
-    pub fanart_url: Option<&'a str>, // 背景图URL
-    pub upper_face_url: Option<&'a str>, // UP主头像URL（用于演员thumb）
+    pub thumb_url: Option<&'a str>,                // 缩略图URL
+    pub fanart_url: Option<&'a str>,               // 背景图URL
+    pub upper_face_url: Option<&'a str>,           // UP主头像URL（用于演员thumb）
 }
 
 pub struct Season<'a> {
@@ -168,6 +168,42 @@ impl NFO<'_> {
         } else {
             Cow::Owned(input.chars().filter(|&ch| Self::is_valid_xml_char(ch)).collect())
         }
+    }
+
+    async fn write_genre_tag(
+        writer: &mut Writer<&mut BufWriter<&mut Vec<u8>>>,
+        genre: &str,
+        config: &NFOConfig,
+    ) -> std::result::Result<(), Error> {
+        if !config.include_genre {
+            return Ok(());
+        }
+
+        writer
+            .create_element("genre")
+            .write_text_content_async(BytesText::new(genre))
+            .await?;
+
+        Ok(())
+    }
+
+    async fn write_genre_tags<'a, I>(
+        writer: &mut Writer<&mut BufWriter<&mut Vec<u8>>>,
+        genres: I,
+        config: &NFOConfig,
+    ) -> std::result::Result<(), Error>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        if !config.include_genre {
+            return Ok(());
+        }
+
+        for genre in genres {
+            Self::write_genre_tag(writer, genre, config).await?;
+        }
+
+        Ok(())
     }
 
     pub async fn generate_nfo(self) -> Result<String> {
@@ -307,25 +343,14 @@ impl NFO<'_> {
                     .await?;
 
                 // 类型标签
-                if let Some(tags) = movie.tags {
-                    for tag in tags {
-                        writer
-                            .create_element("genre")
-                            .write_text_content_async(BytesText::new(&tag))
-                            .await?;
-                    }
+                if let Some(ref tags) = movie.tags {
+                    Self::write_genre_tags(writer, tags.iter().map(String::as_str), config).await?;
                 }
 
                 // 为番剧剧场版添加默认类型标签
                 if Self::is_bangumi_video(movie.category) {
-                    writer
-                        .create_element("genre")
-                        .write_text_content_async(BytesText::new("动画"))
-                        .await?;
-                    writer
-                        .create_element("genre")
-                        .write_text_content_async(BytesText::new("剧场版"))
-                        .await?;
+                    Self::write_genre_tag(writer, "动画", config).await?;
+                    Self::write_genre_tag(writer, "剧场版", config).await?;
                 }
 
                 // 国家信息
@@ -712,13 +737,8 @@ impl NFO<'_> {
                 }
 
                 // 类型标签
-                if let Some(tags) = tvshow.tags {
-                    for tag in tags {
-                        writer
-                            .create_element("genre")
-                            .write_text_content_async(BytesText::new(&tag))
-                            .await?;
-                    }
+                if let Some(ref tags) = tvshow.tags {
+                    Self::write_genre_tags(writer, tags.iter().map(String::as_str), config).await?;
                 }
 
                 // 国家信息
@@ -1061,20 +1081,12 @@ impl NFO<'_> {
 
                 // 类型标签
                 if let Some(ref genres) = episode.genres {
-                    for genre in genres {
-                        writer
-                            .create_element("genre")
-                            .write_text_content_async(BytesText::new(genre))
-                            .await?;
-                    }
+                    Self::write_genre_tags(writer, genres.iter().map(String::as_str), config).await?;
                 }
 
                 // 为番剧添加默认类型标签
                 if Self::is_bangumi_video(episode.category) {
-                    writer
-                        .create_element("genre")
-                        .write_text_content_async(BytesText::new("动画"))
-                        .await?;
+                    Self::write_genre_tag(writer, "动画", config).await?;
                 }
 
                 // 国家信息
@@ -1443,13 +1455,8 @@ impl NFO<'_> {
                 }
 
                 // 类型标签
-                if let Some(tags) = season.tags {
-                    for tag in tags {
-                        writer
-                            .create_element("genre")
-                            .write_text_content_async(BytesText::new(&tag))
-                            .await?;
-                    }
+                if let Some(ref tags) = season.tags {
+                    Self::write_genre_tags(writer, tags.iter().map(String::as_str), config).await?;
                 }
 
                 // 国家信息
@@ -2646,6 +2653,18 @@ impl<'a> Season<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    async fn render_movie_nfo_with_config(movie: Movie<'_>, config: &NFOConfig) -> String {
+        let mut buffer = Vec::new();
+        let mut tokio_buffer = BufWriter::new(&mut buffer);
+        let writer = Writer::new_with_indent(&mut tokio_buffer, b' ', 4);
+
+        NFO::write_movie_nfo(writer, movie, config).await.unwrap();
+        tokio_buffer.flush().await.unwrap();
+
+        String::from_utf8(buffer).unwrap()
+    }
 
     #[tokio::test]
     async fn test_generate_nfo() {
@@ -2827,12 +2846,8 @@ mod tests {
         assert!(generated_episode.contains("<actor>"));
         assert!(generated_episode.contains("<name>まん酱</name>"));
         assert!(generated_episode.contains("<role>UP主</role>"));
-        assert!(generated_episode.contains(
-            "<thumb>https://i1.hdslb.com/bfs/face/test-face.jpg</thumb>"
-        ));
-        assert!(generated_episode.contains(
-            "<profile>https://space.bilibili.com/5328643</profile>"
-        ));
+        assert!(generated_episode.contains("<thumb>https://i1.hdslb.com/bfs/face/test-face.jpg</thumb>"));
+        assert!(generated_episode.contains("<profile>https://space.bilibili.com/5328643</profile>"));
         assert!(generated_episode.contains("<order>1</order>"));
     }
 
@@ -3081,6 +3096,40 @@ mod tests {
         assert_eq!(actor_info, Some(("测试UP主".to_string(), "UP主".to_string())));
 
         println!("空UP主处理策略测试通过");
+    }
+
+    #[tokio::test]
+    async fn test_genre_tags_can_be_disabled() {
+        use crate::config::NFOConfig;
+
+        let video = video::Model {
+            intro: "测试关闭genre标签".to_string(),
+            name: "《名侦探柯南 水平线上的阴谋》".to_string(),
+            upper_id: 0,
+            upper_name: "".to_string(),
+            category: 1,
+            show_season_type: Some(2),
+            favtime: chrono::NaiveDateTime::new(
+                chrono::NaiveDate::from_ymd_opt(2020, 5, 22).unwrap(),
+                chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            ),
+            pubtime: chrono::NaiveDateTime::new(
+                chrono::NaiveDate::from_ymd_opt(2020, 5, 22).unwrap(),
+                chrono::NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+            ),
+            bvid: "BV1Hz411q7vB".to_string(),
+            tags: Some(serde_json::json!(["推理", "悬疑"])),
+            ..Default::default()
+        };
+
+        let config = NFOConfig {
+            include_genre: false,
+            ..Default::default()
+        };
+
+        let movie_nfo = render_movie_nfo_with_config(Movie::from(&video), &config).await;
+
+        assert!(!movie_nfo.contains("<genre>"));
     }
 
     #[tokio::test]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -6,7 +6,14 @@ export interface ApiResponse<T> {
 }
 
 // 排序字段枚举
-export type SortBy = 'id' | 'name' | 'upper_name' | 'created_at' | 'pubtime' | 'is_charge_video' | 'file_size';
+export type SortBy =
+	| 'id'
+	| 'name'
+	| 'upper_name'
+	| 'created_at'
+	| 'pubtime'
+	| 'is_charge_video'
+	| 'file_size';
 
 // 排序顺序枚举
 export type SortOrder = 'asc' | 'desc';
@@ -264,6 +271,7 @@ export interface ConfigResponse {
 	time_format: string;
 	interval: number;
 	nfo_time_type: string;
+	nfo_include_genre: boolean;
 	parallel_download_enabled: boolean;
 	parallel_download_threads: number;
 	parallel_download_use_aria2: boolean;
@@ -402,6 +410,7 @@ export interface UpdateConfigRequest {
 	time_format?: string;
 	interval?: number;
 	nfo_time_type?: string;
+	nfo_include_genre?: boolean;
 	parallel_download_enabled?: boolean;
 	parallel_download_threads?: number;
 	parallel_download_use_aria2?: boolean;

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -146,6 +146,7 @@
 
 	const DEFAULT_CONFIG_VALUES = {
 		interval: 1200,
+		nfoIncludeGenre: true,
 		bindAddress: '0.0.0.0:12345',
 		parallelDownloadThreads: 4,
 		codecs: ['AVC', 'HEV', 'AV1'],
@@ -219,6 +220,7 @@
 	let timeFormat = '%Y-%m-%d';
 	let interval = 1200;
 	let nfoTimeType = 'favtime';
+	let nfoIncludeGenre = true;
 	let bindAddress = '0.0.0.0:12345';
 	let parallelDownloadEnabled = false;
 	let parallelDownloadThreads = 4;
@@ -580,6 +582,7 @@
 		timeFormat = config.time_format || '';
 		interval = config.interval || 1200;
 		nfoTimeType = config.nfo_time_type || 'favtime';
+		nfoIncludeGenre = config.nfo_include_genre ?? DEFAULT_CONFIG_VALUES.nfoIncludeGenre;
 		bindAddress = config.bind_address || '0.0.0.0:12345';
 		parallelDownloadEnabled = config.parallel_download_enabled || false;
 		parallelDownloadThreads = config.parallel_download_threads || 4;
@@ -903,6 +906,7 @@
 			time_format: timeFormat,
 			interval: normalizeNumberInput(interval, DEFAULT_CONFIG_VALUES.interval),
 			nfo_time_type: nfoTimeType,
+			nfo_include_genre: nfoIncludeGenre,
 			bind_address: bindAddress,
 			parallel_download_enabled: parallelDownloadEnabled,
 			parallel_download_threads: normalizeNumberInput(
@@ -950,15 +954,9 @@
 				danmakuBottomPercentage,
 				DEFAULT_CONFIG_VALUES.danmakuBottomPercentage
 			),
-			danmaku_opacity: normalizeNumberInput(
-				danmakuOpacity,
-				DEFAULT_CONFIG_VALUES.danmakuOpacity
-			),
+			danmaku_opacity: normalizeNumberInput(danmakuOpacity, DEFAULT_CONFIG_VALUES.danmakuOpacity),
 			danmaku_bold: danmakuBold,
-			danmaku_outline: normalizeNumberInput(
-				danmakuOutline,
-				DEFAULT_CONFIG_VALUES.danmakuOutline
-			),
+			danmaku_outline: normalizeNumberInput(danmakuOutline, DEFAULT_CONFIG_VALUES.danmakuOutline),
 			danmaku_time_offset: normalizeNumberInput(
 				danmakuTimeOffset,
 				DEFAULT_CONFIG_VALUES.danmakuTimeOffset
@@ -993,10 +991,7 @@
 				concurrentVideo,
 				DEFAULT_CONFIG_VALUES.concurrentVideo
 			),
-			concurrent_page: normalizeNumberInput(
-				concurrentPage,
-				DEFAULT_CONFIG_VALUES.concurrentPage
-			),
+			concurrent_page: normalizeNumberInput(concurrentPage, DEFAULT_CONFIG_VALUES.concurrentPage),
 			rate_limit: normalizeNumberInput(rateLimit, DEFAULT_CONFIG_VALUES.rateLimit),
 			rate_duration: normalizeNumberInput(rateDuration, DEFAULT_CONFIG_VALUES.rateDuration),
 			// 其他设置
@@ -1803,6 +1798,23 @@
 					选择NFO文件中使用的时间类型。
 					<span class="font-medium text-amber-600">注意：</span>
 					更改此设置后，系统会自动重置所有NFO相关任务状态，并立即开始重新生成NFO文件以应用新的时间类型。
+				</p>
+			</div>
+
+			<div class="space-y-2">
+				<div class="flex items-center space-x-2">
+					<input
+						type="checkbox"
+						id="nfo-include-genre"
+						bind:checked={nfoIncludeGenre}
+						class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+					/>
+					<Label for="nfo-include-genre" class="text-sm">NFO写入&lt;genre&gt;标签</Label>
+				</div>
+				<p class="text-muted-foreground text-sm">
+					关闭后，新生成的 NFO 不再写入 <code>&lt;genre&gt;</code> 标签。
+					<span class="font-medium text-amber-600">注意：</span>
+					更改此设置后，系统会自动重置所有NFO相关任务状态，并立即开始重新生成NFO文件。
 				</p>
 			</div>
 


### PR DESCRIPTION
## 改动
- 设置页新增“NFO写入<genre>标签”开关
- 后端新增 `nfo_include_genre` 配置，并接入配置读取、保存、任务队列更新和 NFO 重置重生成
- NFO 生成逻辑按开关控制 `<genre>` 输出，番剧默认补的类型标签也一起受控
- 补充关闭 `<genre>` 输出的测试

## 验证
- `cargo test test_genre_tags_can_be_disabled -p bili_sync -- --nocapture`

## 说明
- `npx prettier --check src/routes/settings/+page.svelte src/lib/types.ts` 已通过