### PR TITLE
修复登录失效通知和凭据自动刷新

### DIFF
--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -306,33 +306,22 @@ impl BiliClient {
         let new_credential = credential.refresh(&self.client).await?;
         config.credential.store(Some(Arc::new(new_credential.clone())));
 
-        // 将刷新后的credential通过任务队列保存到数据库
-        if let Err(e) = self.enqueue_credential_save_task(new_credential).await {
-            warn!("将credential刷新任务加入队列失败: {}", e);
-        } else {
-            info!("credential已刷新，保存任务已加入队列");
-        }
+        self.persist_refreshed_credential(&config).await?;
+        info!("credential已刷新并保存到数据库");
 
         Ok(())
     }
 
-    /// 将credential刷新任务加入配置任务队列
-    async fn enqueue_credential_save_task(&self, new_credential: crate::bilibili::Credential) -> Result<()> {
-        use uuid::Uuid;
-
-        // 更新内存中的配置
-        let updated_config = crate::config::reload_config();
-        updated_config.credential.store(Some(Arc::new(new_credential)));
-
-        // 创建重载配置任务，让任务队列处理数据库保存
-        let reload_task = crate::task::ReloadConfigTask {
-            task_id: Uuid::new_v4().to_string(),
-        };
-
-        // 将任务加入队列
-        let db = Arc::new(crate::database::setup_database().await);
-        crate::task::enqueue_reload_task(reload_task, &db).await?;
-
+    async fn persist_refreshed_credential(&self, config: &crate::config::Config) -> Result<()> {
+        let manager = crate::config::get_config_manager().context("配置管理器未初始化，无法保存刷新后的 credential")?;
+        let credential_json = serde_json::to_value(&config.credential).context("序列化刷新后的 credential 失败")?;
+        manager
+            .update_config_item("credential", credential_json)
+            .await
+            .context("保存刷新后的 credential 到数据库失败")?;
+        crate::config::reload_config_bundle()
+            .await
+            .context("刷新 credential 后重新加载配置失败")?;
         Ok(())
     }
 

--- a/crates/bili_sync/src/bilibili/credential.rs
+++ b/crates/bili_sync/src/bilibili/credential.rs
@@ -98,11 +98,35 @@ impl Credential {
     }
 
     pub async fn refresh(&self, client: &Client) -> Result<Self> {
+        self.ensure_can_refresh()?;
         let correspond_path = Self::get_correspond_path();
-        let csrf = self.get_refresh_csrf(client, correspond_path).await?;
-        let new_credential = self.get_new_credential(client, &csrf).await?;
-        self.confirm_refresh(client, &new_credential).await?;
+        let csrf = self.get_refresh_csrf(client, correspond_path).await.context(
+            "获取B站 Cookie 刷新 csrf 失败，可能是旧 Cookie 已失效、被手动退出登录，或和 ac_time_value 不匹配",
+        )?;
+        let new_credential = self
+            .get_new_credential(client, &csrf)
+            .await
+            .context("刷新B站 Cookie 失败，可能是 ac_time_value 已失效或和当前 Cookie 不匹配")?;
+        self.confirm_refresh(client, &new_credential)
+            .await
+            .context("确认B站 Cookie 刷新失败")?;
         Ok(new_credential)
+    }
+
+    fn ensure_can_refresh(&self) -> Result<()> {
+        ensure!(
+            !self.sessdata.trim().is_empty(),
+            "刷新B站 Cookie 失败：缺少 SESSDATA，请重新登录并更新整套认证信息"
+        );
+        ensure!(
+            !self.bili_jct.trim().is_empty(),
+            "刷新B站 Cookie 失败：缺少 bili_jct，请重新登录并更新整套认证信息"
+        );
+        ensure!(
+            !self.ac_time_value.trim().is_empty(),
+            "刷新B站 Cookie 失败：缺少 ac_time_value，请重新登录并更新整套认证信息"
+        );
+        Ok(())
     }
 
     fn get_correspond_path() -> String {
@@ -116,7 +140,8 @@ JNrRuoEUXpabUzGB8QIDAQAB
 -----END PUBLIC KEY-----",
         )
         .expect("fail to decode public key");
-        let ts = chrono::Local::now().timestamp_millis();
+        // B站会校验 correspondPath 内的时间戳；本机时间略快时可能拿不到 refresh_csrf。
+        let ts = chrono::Local::now().timestamp_millis() - 20000;
         let data = format!("refresh_{}", ts).into_bytes();
         let mut rng = rand::rngs::OsRng;
         let encrypted = key
@@ -132,11 +157,14 @@ JNrRuoEUXpabUzGB8QIDAQAB
                 format!("https://www.bilibili.com/correspond/1/{}", correspond_path).as_str(),
                 Some(self),
             )
-            .header(header::COOKIE, "Domain=.bilibili.com")
             .send()
-            .await?
-            .error_for_status()?;
-        regex_find(r#"<div id="1-name">(.+?)</div>"#, res.text().await?.as_str())
+            .await
+            .context("请求B站 Cookie 刷新 csrf 页面失败")?
+            .error_for_status()
+            .context("B站 Cookie 刷新 csrf 页面返回非成功 HTTP 状态")?;
+        let text = res.text().await.context("读取B站 Cookie 刷新 csrf 页面失败")?;
+        regex_find(r#"<div id="1-name">(.+?)</div>"#, text.as_str())
+            .context("B站 Cookie 刷新 csrf 页面未返回 refresh_csrf")
     }
 
     async fn get_new_credential(&self, client: &Client, csrf: &str) -> Result<Credential> {
@@ -146,7 +174,6 @@ JNrRuoEUXpabUzGB8QIDAQAB
                 "https://passport.bilibili.com/x/passport-login/web/cookie/refresh",
                 Some(self),
             )
-            .header(header::COOKIE, "Domain=.bilibili.com")
             .form(&[
                 // 这里不是 json，而是 form data
                 ("csrf", self.bili_jct.as_str()),
@@ -155,11 +182,18 @@ JNrRuoEUXpabUzGB8QIDAQAB
                 ("source", "main_web"),
             ])
             .send()
-            .await?
-            .error_for_status()?;
+            .await
+            .context("请求B站 Cookie 刷新接口失败")?
+            .error_for_status()
+            .context("B站 Cookie 刷新接口返回非成功 HTTP 状态")?;
         // 必须在 .json 前取出 headers，否则 res 会被消耗
         let headers = std::mem::take(res.headers_mut());
-        let res = res.json::<serde_json::Value>().await?.validate()?;
+        let res = res
+            .json::<serde_json::Value>()
+            .await
+            .context("解析B站 Cookie 刷新响应失败")?
+            .validate()
+            .context("B站 Cookie 刷新接口返回失败")?;
         let set_cookies = headers.get_all(header::SET_COOKIE);
         let mut credential = Self {
             buvid3: self.buvid3.clone(),
@@ -176,7 +210,7 @@ JNrRuoEUXpabUzGB8QIDAQAB
             .collect();
         ensure!(
             cookies.len() == required_cookies.len(),
-            "not all required cookies found"
+            "B站 Cookie 刷新响应缺少必要 Set-Cookie 字段: SESSDATA/bili_jct/DedeUserID"
         );
         for cookie in cookies {
             match cookie.name() {
@@ -188,7 +222,7 @@ JNrRuoEUXpabUzGB8QIDAQAB
         }
         match res["data"]["refresh_token"].as_str() {
             Some(token) => credential.ac_time_value = token.to_string(),
-            None => bail!("refresh_token not found"),
+            None => bail!("B站 Cookie 刷新响应缺少 refresh_token"),
         }
         Ok(credential)
     }
@@ -206,11 +240,15 @@ JNrRuoEUXpabUzGB8QIDAQAB
                 ("refresh_token", self.ac_time_value.as_str()),
             ])
             .send()
-            .await?
-            .error_for_status()?
+            .await
+            .context("请求B站 Cookie 刷新确认接口失败")?
+            .error_for_status()
+            .context("B站 Cookie 刷新确认接口返回非成功 HTTP 状态")?
             .json::<serde_json::Value>()
-            .await?
-            .validate()?;
+            .await
+            .context("解析B站 Cookie 刷新确认响应失败")?
+            .validate()
+            .context("B站 Cookie 刷新确认接口返回失败")?;
         Ok(())
     }
 }
@@ -302,6 +340,23 @@ mod tests {
             serde_urlencoded::to_string(query).unwrap().replace('+', "%20"),
             "bar=%E4%BA%94%E4%B8%80%E5%9B%9B&baz=1919810&foo=one%20one%20four"
         );
+    }
+
+    #[test]
+    fn refresh_requires_complete_refresh_material() {
+        let mut credential = Credential {
+            sessdata: "sessdata".to_string(),
+            bili_jct: "csrf".to_string(),
+            ac_time_value: "refresh-token".to_string(),
+            ..Default::default()
+        };
+        assert!(credential.ensure_can_refresh().is_ok());
+
+        credential.ac_time_value.clear();
+        let err = credential
+            .ensure_can_refresh()
+            .expect_err("缺少 ac_time_value 时不能刷新");
+        assert!(format!("{:#}", err).contains("缺少 ac_time_value"));
     }
 
     #[test]

--- a/crates/bili_sync/src/main.rs
+++ b/crates/bili_sync/src/main.rs
@@ -25,7 +25,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 // 移除未使用的Lazy导入
-use task::{http_server, video_downloader};
+use task::{credential_refresh_scheduler, http_server, video_downloader};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
@@ -160,6 +160,12 @@ async fn async_main() -> Result<()> {
     }
 
     // SQLite配置已经在database::setup_database中设置了mmap，不再需要额外的初始化
+    spawn_task(
+        "B站凭据自动刷新",
+        credential_refresh_scheduler(),
+        &tracker,
+        token.clone(),
+    );
     spawn_task("定时下载", video_downloader(connection), &tracker, token.clone());
 
     tracker.close();

--- a/crates/bili_sync/src/task/mod.rs
+++ b/crates/bili_sync/src/task/mod.rs
@@ -2,7 +2,7 @@ mod http_server;
 pub mod video_downloader;
 
 pub use http_server::http_server;
-pub use video_downloader::video_downloader;
+pub use video_downloader::{credential_refresh_scheduler, video_downloader};
 
 use crate::utils::live_updates::{notify_queue_status_changed, notify_videos_changed};
 use crate::utils::time_format::now_standard_string;

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration as StdDuration;
 
 use anyhow::Result;
-use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{Duration, Local, NaiveDate, NaiveDateTime, NaiveTime};
 use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, Set};
 use tracing::{debug, error, info, warn};
 
@@ -22,6 +23,12 @@ use crate::utils::scan_id_tracker::{
 use crate::utils::time_format::{now_naive, now_standard_string, parse_time_string, STANDARD_TIME_FORMAT};
 use crate::workflow::process_video_source;
 use bili_sync_entity::entities;
+
+const VIDEO_DOWNLOADER_LOG_TARGET: &str = "bili_sync::task::video_downloader";
+const DAILY_CREDENTIAL_REFRESH_HOUR: u32 = 1;
+const LOGIN_EXPIRED_NOTIFICATION_TITLE: &str = "B站登录状态异常";
+const LOGIN_EXPIRED_NOTIFICATION_MESSAGE: &str =
+    "检测到B站登录状态过期或未登录，自动刷新 Cookie 失败；请重新扫码登录或更新整套认证信息（SESSDATA、bili_jct、DedeUserID、ac_time_value）";
 
 fn is_submission_lookup_retryable_error(err: &anyhow::Error) -> bool {
     matches!(
@@ -56,7 +63,9 @@ fn format_wbi_fetch_failure_message(err: &anyhow::Error) -> String {
 
 fn is_wbi_login_expired_error(err: &anyhow::Error) -> bool {
     let error_msg = format!("{:#}", err);
-    error_msg.contains("status code: -101") || error_msg.contains("账号未登录")
+    error_msg.contains("status code: -101")
+        || error_msg.contains("账号未登录")
+        || error_msg.contains("no credential found")
 }
 
 fn is_wbi_fetch_retryable_error(err: &anyhow::Error) -> bool {
@@ -192,6 +201,59 @@ fn is_watch_later_empty_error(err: &anyhow::Error) -> bool {
 async fn send_source_status_notification(title: &str, message: &str, context: Option<&str>) {
     if let Err(notify_err) = crate::utils::notification::send_error_notification(title, message, context).await {
         warn!("发送通知失败: {}", notify_err);
+    }
+}
+
+fn add_video_downloader_log_entry(level: crate::api::handler::LogLevel, message: &str) {
+    crate::api::handler::add_log_entry(
+        level,
+        message.to_string(),
+        Some(VIDEO_DOWNLOADER_LOG_TARGET.to_string()),
+    );
+}
+
+async fn record_login_expired_warning(message: &str, context: Option<&str>) {
+    add_video_downloader_log_entry(crate::api::handler::LogLevel::Warn, message);
+    send_source_status_notification(LOGIN_EXPIRED_NOTIFICATION_TITLE, message, context).await;
+}
+
+fn next_daily_credential_refresh_after(now: NaiveDateTime) -> NaiveDateTime {
+    let refresh_time = NaiveTime::from_hms_opt(DAILY_CREDENTIAL_REFRESH_HOUR, 0, 0).unwrap();
+    let today_refresh = NaiveDateTime::new(now.date(), refresh_time);
+    if now < today_refresh {
+        today_refresh
+    } else {
+        today_refresh + Duration::days(1)
+    }
+}
+
+fn next_daily_credential_refresh_wait() -> (NaiveDateTime, StdDuration) {
+    let now = Local::now().naive_local();
+    let next_run = next_daily_credential_refresh_after(now);
+    let wait = (next_run - now).to_std().unwrap_or_else(|_| StdDuration::from_secs(0));
+    (next_run, wait)
+}
+
+pub async fn credential_refresh_scheduler() {
+    let bili_client = BiliClient::new(String::new());
+
+    loop {
+        let (next_run, wait) = next_daily_credential_refresh_wait();
+        info!(
+            "B站凭据自动刷新任务已启动，下次检查时间: {}",
+            next_run.format(STANDARD_TIME_FORMAT)
+        );
+        tokio::time::sleep(wait).await;
+
+        info!("开始执行每日B站凭据检查与自动刷新任务");
+        match bili_client.check_refresh().await {
+            Ok(()) => info!("每日B站凭据检查与自动刷新任务执行完毕"),
+            Err(err) => {
+                warn!("每日B站凭据检查与自动刷新任务失败: {:#}", err);
+                let context = format!("每日自动刷新失败: {:#}", err);
+                record_login_expired_warning(LOGIN_EXPIRED_NOTIFICATION_MESSAGE, Some(context.as_str())).await;
+            }
+        }
     }
 }
 
@@ -726,44 +788,48 @@ pub async fn video_downloader(connection: Arc<DatabaseConnection>) {
                 }
                 Err(e) => {
                     if is_wbi_login_expired_error(&e) {
-                        warn!("检测到登录状态过期或未登录，尝试自动续登并重试...");
+                        warn!("检测到登录状态过期或未登录，尝试自动刷新 Cookie 并重试...");
                         match bili_client.check_refresh().await {
                             Ok(()) => match fetch_wbi_mixin_key_with_retry(&bili_client).await {
                                 Ok(Some(mixin_key)) => {
-                                    info!("自动续登成功，已恢复登录状态");
+                                    info!("自动刷新 Cookie 成功，已恢复登录状态");
                                     bilibili::set_global_mixin_key(mixin_key);
                                 }
                                 Ok(_) => {
-                                    error!("自动续登后仍无法获取B站签名信息，等待下一轮执行");
-                                    crate::api::handler::add_log_entry(
-                                        crate::api::handler::LogLevel::Warn,
-                                        "自动续登后仍无法恢复登录状态，请检查认证信息".to_string(),
-                                        Some("bili_sync::task::video_downloader".to_string()),
-                                    );
+                                    error!("自动刷新 Cookie 后仍无法获取B站签名信息，等待下一轮执行");
+                                    record_login_expired_warning(
+                                        "自动刷新 Cookie 后仍无法恢复登录状态，请检查认证信息",
+                                        Some(
+                                            "自动刷新 Cookie 后仍无法获取B站签名信息，扫描已停止。请重新扫码登录或更新整套认证信息。",
+                                        ),
+                                    )
+                                    .await;
                                     TASK_CONTROLLER.set_scanning(false);
                                     crate::utils::task_notifier::TASK_STATUS_NOTIFIER.set_finished();
                                     break 'inner;
                                 }
                                 Err(retry_err) => {
-                                    warn!("自动续登失败或重试仍未登录: {:#}", retry_err);
-                                    crate::api::handler::add_log_entry(
-                                        crate::api::handler::LogLevel::Warn,
-                                        "检测到登录状态过期或未登录，自动续登失败，请更新配置文件中的SESSDATA等认证信息".to_string(),
-                                        Some("bili_sync::task::video_downloader".to_string()),
-                                    );
+                                    warn!("自动刷新 Cookie 失败或重试仍未登录: {:#}", retry_err);
+                                    let notification_context =
+                                        format!("自动刷新 Cookie 后重试仍未登录: {:#}", retry_err);
+                                    record_login_expired_warning(
+                                        LOGIN_EXPIRED_NOTIFICATION_MESSAGE,
+                                        Some(notification_context.as_str()),
+                                    )
+                                    .await;
                                     TASK_CONTROLLER.set_scanning(false);
                                     crate::utils::task_notifier::TASK_STATUS_NOTIFIER.set_finished();
                                     break 'inner;
                                 }
                             },
                             Err(refresh_err) => {
-                                warn!("检测到登录状态过期或未登录，自动续登失败: {:#}", refresh_err);
-                                crate::api::handler::add_log_entry(
-                                    crate::api::handler::LogLevel::Warn,
-                                    "检测到登录状态过期或未登录，自动续登失败，请更新配置文件中的SESSDATA等认证信息"
-                                        .to_string(),
-                                    Some("bili_sync::task::video_downloader".to_string()),
-                                );
+                                warn!("检测到登录状态过期或未登录，自动刷新 Cookie 失败: {:#}", refresh_err);
+                                let notification_context = format!("自动刷新 Cookie 失败: {:#}", refresh_err);
+                                record_login_expired_warning(
+                                    LOGIN_EXPIRED_NOTIFICATION_MESSAGE,
+                                    Some(notification_context.as_str()),
+                                )
+                                .await;
                                 TASK_CONTROLLER.set_scanning(false);
                                 crate::utils::task_notifier::TASK_STATUS_NOTIFIER.set_finished();
                                 break 'inner;
@@ -776,7 +842,7 @@ pub async fn video_downloader(connection: Arc<DatabaseConnection>) {
                         crate::api::handler::add_log_entry(
                             crate::api::handler::LogLevel::Error,
                             friendly_message,
-                            Some("bili_sync::task::video_downloader".to_string()),
+                            Some(VIDEO_DOWNLOADER_LOG_TARGET.to_string()),
                         );
 
                         TASK_CONTROLLER.set_scanning(false);
@@ -1343,6 +1409,46 @@ mod tests {
             .await
             .expect("应能完成测试数据库迁移");
         db
+    }
+
+    #[test]
+    fn wbi_login_expired_error_detects_bilibili_login_errors() {
+        assert!(is_wbi_login_expired_error(&anyhow::anyhow!(
+            "Bilibili api error, status code: -101"
+        )));
+        assert!(is_wbi_login_expired_error(&anyhow::anyhow!("账号未登录")));
+    }
+
+    #[test]
+    fn wbi_login_expired_error_detects_missing_credential() {
+        assert!(is_wbi_login_expired_error(&anyhow::anyhow!("no credential found")));
+    }
+
+    #[test]
+    fn daily_credential_refresh_runs_at_next_one_am() {
+        let before_one = NaiveDate::from_ymd_opt(2026, 5, 12)
+            .unwrap()
+            .and_hms_opt(0, 30, 0)
+            .unwrap();
+        let after_one = NaiveDate::from_ymd_opt(2026, 5, 12)
+            .unwrap()
+            .and_hms_opt(1, 30, 0)
+            .unwrap();
+
+        assert_eq!(
+            next_daily_credential_refresh_after(before_one),
+            NaiveDate::from_ymd_opt(2026, 5, 12)
+                .unwrap()
+                .and_hms_opt(1, 0, 0)
+                .unwrap()
+        );
+        assert_eq!(
+            next_daily_credential_refresh_after(after_one),
+            NaiveDate::from_ymd_opt(2026, 5, 13)
+                .unwrap()
+                .and_hms_opt(1, 0, 0)
+                .unwrap()
+        );
     }
 
     async fn insert_test_watch_later(db: &DatabaseConnection, id: i32, enabled: bool) {


### PR DESCRIPTION
﻿## 改动
- 登录过期或未登录时，自动刷新 Cookie 失败会发送错误通知，提示用户重新扫码登录或更新整套凭据。
- 细化 Cookie 刷新链路错误原因，区分缺少凭据、refresh_csrf 获取失败、刷新接口失败和确认刷新失败。
- 启动独立的每日 1 点凭据检查任务，正常过期时主动刷新并保存到数据库。
- 刷新成功后直接落库并热重载配置，避免只更新内存。

## 原因
Issue #171 反馈登录失败后只有日志，没有提醒，导致投稿源更新后无法及时下载。排查后确认当前逻辑只有扫描时被动刷新，没有上游那种每日主动刷新任务；并且刷新失败提示过于笼统。

Closes #171

## 验证
- cargo test -p bili_sync daily_credential_refresh_runs_at_next_one_am -- --nocapture
- cargo test -p bili_sync refresh_requires_complete_refresh_material -- --nocapture
- cargo test -p bili_sync wbi_login_expired_error -- --nocapture
- cargo check -p bili_sync
