### PR TITLE
pr: 修复凭据刷新网络误报和搜索错误诊断

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -11904,6 +11904,7 @@ pub async fn search_bilibili(
     // 特殊处理：当搜索类型为media_bangumi时，同时搜索番剧和影视
     let mut all_results = Vec::new();
     let mut total_results = 0u32;
+    let mut num_pages = 1u32;
 
     if params.search_type == "media_bangumi" {
         // 搜索番剧
@@ -11917,6 +11918,7 @@ pub async fn search_bilibili(
             .await
         {
             Ok(bangumi_wrapper) => {
+                num_pages = num_pages.max(bangumi_wrapper.num_pages);
                 all_results.extend(bangumi_wrapper.results);
                 total_results += bangumi_wrapper.total;
             }
@@ -11936,6 +11938,7 @@ pub async fn search_bilibili(
             .await
         {
             Ok(ft_wrapper) => {
+                num_pages = num_pages.max(ft_wrapper.num_pages);
                 all_results.extend(ft_wrapper.results);
                 total_results += ft_wrapper.total;
             }
@@ -11955,6 +11958,7 @@ pub async fn search_bilibili(
             .await
         {
             Ok(search_wrapper) => {
+                num_pages = search_wrapper.num_pages;
                 all_results = search_wrapper.results;
                 total_results = search_wrapper.total;
             }
@@ -11991,6 +11995,7 @@ pub async fn search_bilibili(
         success: true,
         results: api_results,
         total: total_results,
+        num_pages,
         page: params.page,
         page_size: params.page_size,
     }))

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -29,10 +29,10 @@ use utoipa::OpenApi;
 use crate::api::auth::OpenAPIAuth;
 use crate::api::error::InnerApiError;
 use crate::api::request::{
-    AddVideoSourceRequest, BatchUpdateConfigRequest, ConfigHistoryRequest, ConfigMigrationRequest, QRGenerateRequest,
-    QRPollRequest, ResetSpecificTasksRequest, ResetVideoSourcePathRequest, SetupAuthTokenRequest,
-    SubmissionVideosRequest, UpdateConfigItemRequest, UpdateConfigRequest, UpdateCredentialRequest,
-    UpdateVideoStatusRequest, VideosRequest,
+    AddVideoSourceRequest, BatchUpdateConfigRequest, ConfigHistoryRequest, ConfigMigrationRequest,
+    CredentialRefreshTestRequest, QRGenerateRequest, QRPollRequest, ResetSpecificTasksRequest,
+    ResetVideoSourcePathRequest, SetupAuthTokenRequest, SubmissionVideosRequest, UpdateConfigItemRequest,
+    UpdateConfigRequest, UpdateCredentialRequest, UpdateVideoStatusRequest, VideosRequest,
 };
 use crate::api::response::{
     AddVideoSourceResponse, BangumiSeasonInfo, BangumiSourceListResponse, BangumiSourceOption,
@@ -14074,12 +14074,16 @@ fn redact_credential_refresh_details(mut details: String, credential: Option<&cr
 #[utoipa::path(
     post,
     path = "/api/credential/test-refresh",
+    request_body = CredentialRefreshTestRequest,
     responses(
         (status = 200, description = "凭据刷新诊断完成", body = CredentialRefreshTestResponse),
         (status = 500, description = "服务器内部错误", body = String)
     )
 )]
-pub async fn test_credential_refresh() -> Result<ApiResponse<CredentialRefreshTestResponse>, ApiError> {
+pub async fn test_credential_refresh(
+    payload: Option<Json<CredentialRefreshTestRequest>>,
+) -> Result<ApiResponse<CredentialRefreshTestResponse>, ApiError> {
+    let force = payload.map(|Json(params)| params.force).unwrap_or(false);
     let config = crate::config::reload_config();
     let credential = config.credential.load();
     let credential_fields = credential_field_status(credential.as_deref());
@@ -14128,17 +14132,40 @@ pub async fn test_credential_refresh() -> Result<ApiResponse<CredentialRefreshTe
     }
 
     let bili_client = crate::bilibili::BiliClient::new(String::new());
-    match bili_client.check_refresh().await {
-        Ok(()) => Ok(ApiResponse::ok(CredentialRefreshTestResponse {
-            success: true,
-            message: "B 站凭据检查与自动刷新测试完成".to_string(),
-            stage: "completed".to_string(),
-            error_type: None,
-            should_retry: false,
-            diagnosis: "未复现刷新失败；如果当前 Cookie 不需要刷新，本次只完成刷新状态检查。".to_string(),
-            details: None,
-            credential_fields,
-        })),
+    match bili_client.refresh_credential(force).await {
+        Ok(refreshed) => {
+            let updated_config = crate::config::reload_config();
+            let updated_credential = updated_config.credential.load();
+            let credential_fields = credential_field_status(updated_credential.as_deref());
+            let (message, stage, diagnosis) = if refreshed {
+                (
+                    if force {
+                        "B 站凭据强制刷新完成"
+                    } else {
+                        "B 站凭据自动刷新完成"
+                    },
+                    if force { "force_completed" } else { "completed" },
+                    "已完成完整刷新链路：cookie/info、correspond、cookie/refresh、confirm/refresh。",
+                )
+            } else {
+                (
+                    "B 站返回当前凭据不需要刷新",
+                    "precheck_not_needed",
+                    "本次只完成刷新状态检查，没有执行 cookie/refresh；需要验证完整刷新链路请点强制刷新。",
+                )
+            };
+
+            Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+                success: true,
+                message: message.to_string(),
+                stage: stage.to_string(),
+                error_type: None,
+                should_retry: false,
+                diagnosis: diagnosis.to_string(),
+                details: None,
+                credential_fields,
+            }))
+        }
         Err(err) => {
             let details = format!("{:#}", err);
             let classified = crate::error::ErrorClassifier::classify_error(&err);
@@ -14147,7 +14174,11 @@ pub async fn test_credential_refresh() -> Result<ApiResponse<CredentialRefreshTe
             let details = redact_credential_refresh_details(details, credential.as_deref());
             Ok(ApiResponse::ok(CredentialRefreshTestResponse {
                 success: false,
-                message: "B 站凭据检查或自动刷新测试失败".to_string(),
+                message: if force {
+                    "B 站凭据强制刷新测试失败".to_string()
+                } else {
+                    "B 站凭据检查或自动刷新测试失败".to_string()
+                },
                 stage,
                 error_type: Some(format!("{:?}", classified.error_type)),
                 should_retry: classified.should_retry,

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -38,12 +38,12 @@ use crate::api::response::{
     AddVideoSourceResponse, BangumiSeasonInfo, BangumiSourceListResponse, BangumiSourceOption,
     BetaImageUpdateStatusResponse, ConfigChangeInfo, ConfigHistoryResponse, ConfigItemResponse,
     ConfigMigrationReportResponse, ConfigMigrationStatusResponse, ConfigReloadResponse, ConfigResponse,
-    ConfigValidationResponse, DashBoardResponse, DeleteVideoResponse, DeleteVideoSourceResponse,
-    HotReloadStatusResponse, InitialSetupCheckResponse, MonitoringStatus, PageInfo, QRGenerateResponse, QRPollResponse,
-    QRUserInfo, RefreshDanmakuResponse, ResetAllVideosResponse, ResetVideoResponse, ResetVideoSourcePathResponse,
-    SetupAuthTokenResponse, SubmissionVideosResponse, UpdateConfigResponse, UpdateCredentialResponse,
-    UpdateVideoStatusResponse, VideoInfo, VideoResponse, VideoSource, VideoSourceTag, VideoSourcesResponse,
-    VideosResponse,
+    ConfigValidationResponse, CredentialFieldStatus, CredentialRefreshTestResponse, DashBoardResponse,
+    DeleteVideoResponse, DeleteVideoSourceResponse, HotReloadStatusResponse, InitialSetupCheckResponse,
+    MonitoringStatus, PageInfo, QRGenerateResponse, QRPollResponse, QRUserInfo, RefreshDanmakuResponse,
+    ResetAllVideosResponse, ResetVideoResponse, ResetVideoSourcePathResponse, SetupAuthTokenResponse,
+    SubmissionVideosResponse, UpdateConfigResponse, UpdateCredentialResponse, UpdateVideoStatusResponse, VideoInfo,
+    VideoResponse, VideoSource, VideoSourceTag, VideoSourcesResponse, VideosResponse,
 };
 use crate::api::wrapper::{ApiError, ApiResponse};
 use crate::utils::live_updates::{
@@ -1511,7 +1511,7 @@ mod queue_sse_tests {
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(get_video_sources, get_videos, get_video, get_video_local_cover, refresh_video_danmaku, refresh_page_danmaku, reset_video, reset_all_videos, reset_specific_tasks, update_video_status, add_video_source, update_video_source_enabled, update_video_source_scan_deleted, update_video_source_scan_deleted_once, reset_video_source_path, delete_video_source, reload_config, get_config, update_config, get_bangumi_seasons, search_bilibili, get_user_favorites, get_user_collections, get_user_followings, get_subscribed_collections, get_submission_videos, get_logs, get_queue_status, cancel_queue_task, proxy_image, get_config_item, get_config_history, get_config_migration_status, migrate_config_schema, validate_config, get_hot_reload_status, check_initial_setup, setup_auth_token, update_credential, generate_qr_code, poll_qr_status, get_current_user, clear_credential, pause_scanning_endpoint, resume_scanning_endpoint, get_task_control_status, get_video_play_info, proxy_video_stream, validate_favorite, get_user_favorites_by_uid, get_latest_ingests, get_recent_ingests, test_notification_handler, get_notification_config, update_notification_config, get_notification_status, test_risk_control_handler, get_beta_image_update_status),
+    paths(get_video_sources, get_videos, get_video, get_video_local_cover, refresh_video_danmaku, refresh_page_danmaku, reset_video, reset_all_videos, reset_specific_tasks, update_video_status, add_video_source, update_video_source_enabled, update_video_source_scan_deleted, update_video_source_scan_deleted_once, reset_video_source_path, delete_video_source, reload_config, get_config, update_config, get_bangumi_seasons, search_bilibili, get_user_favorites, get_user_collections, get_user_followings, get_subscribed_collections, get_submission_videos, get_logs, get_queue_status, cancel_queue_task, proxy_image, get_config_item, get_config_history, get_config_migration_status, migrate_config_schema, validate_config, get_hot_reload_status, check_initial_setup, setup_auth_token, update_credential, test_credential_refresh, generate_qr_code, poll_qr_status, get_current_user, clear_credential, pause_scanning_endpoint, resume_scanning_endpoint, get_task_control_status, get_video_play_info, proxy_video_stream, validate_favorite, get_user_favorites_by_uid, get_latest_ingests, get_recent_ingests, test_notification_handler, get_notification_config, update_notification_config, get_notification_status, test_risk_control_handler, get_beta_image_update_status),
     modifiers(&OpenAPIAuth),
     security(
         ("Token" = []),
@@ -13976,6 +13976,187 @@ pub async fn update_credential(
     };
 
     Ok(ApiResponse::ok(response))
+}
+
+fn credential_field_status(credential: Option<&crate::bilibili::Credential>) -> CredentialFieldStatus {
+    match credential {
+        Some(credential) => CredentialFieldStatus {
+            has_credential: true,
+            sessdata_len: credential.sessdata.len(),
+            bili_jct_len: credential.bili_jct.len(),
+            buvid3_len: credential.buvid3.len(),
+            dedeuserid_len: credential.dedeuserid.len(),
+            ac_time_value_len: credential.ac_time_value.len(),
+            has_buvid4: credential.buvid4.as_ref().is_some_and(|value| !value.trim().is_empty()),
+            has_dedeuserid_ckmd5: credential
+                .dedeuserid_ckmd5
+                .as_ref()
+                .is_some_and(|value| !value.trim().is_empty()),
+        },
+        None => CredentialFieldStatus {
+            has_credential: false,
+            sessdata_len: 0,
+            bili_jct_len: 0,
+            buvid3_len: 0,
+            dedeuserid_len: 0,
+            ac_time_value_len: 0,
+            has_buvid4: false,
+            has_dedeuserid_ckmd5: false,
+        },
+    }
+}
+
+fn credential_refresh_failure_stage(details: &str) -> String {
+    let lower = details.to_lowercase();
+    if lower.contains("cookie/info") {
+        "refresh_precheck".to_string()
+    } else if details.contains("刷新 csrf") || lower.contains("correspond") {
+        "refresh_csrf".to_string()
+    } else if details.contains("刷新B站 Cookie") || lower.contains("cookie/refresh") {
+        "refresh_cookie".to_string()
+    } else if details.contains("确认B站 Cookie") || lower.contains("confirm") {
+        "confirm_refresh".to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn credential_refresh_diagnosis(error_type: &crate::error::ErrorType, details: &str) -> String {
+    match error_type {
+        crate::error::ErrorType::Network | crate::error::ErrorType::Timeout => {
+            "运行环境连接 B 站失败，优先检查容器/NAS 网络、DNS、代理或 IPv6 出口；当前凭据不一定失效。".to_string()
+        }
+        crate::error::ErrorType::ServerError | crate::error::ErrorType::RateLimit => {
+            "B 站接口临时不可用或请求受限，通常可以稍后重试；当前凭据不一定失效。".to_string()
+        }
+        crate::error::ErrorType::Authentication | crate::error::ErrorType::Authorization => {
+            "B 站明确返回认证或权限问题，优先重新扫码登录并更新整套凭据。".to_string()
+        }
+        crate::error::ErrorType::Parse => {
+            "B 站返回内容不是预期格式，可能是验证码页、风控页、HTML 错误页或网关异常。".to_string()
+        }
+        _ if details.contains("ac_time_value") => {
+            "自动刷新需要 ac_time_value，并且必须和当前 Cookie 同一批次；请重新扫码或更新整套凭据。".to_string()
+        }
+        _ => "未能归类到明确原因，请查看错误链 details。".to_string(),
+    }
+}
+
+fn redact_credential_refresh_details(mut details: String, credential: Option<&crate::bilibili::Credential>) -> String {
+    let Some(credential) = credential else {
+        return details;
+    };
+
+    let mut secrets = vec![
+        credential.sessdata.as_str(),
+        credential.bili_jct.as_str(),
+        credential.buvid3.as_str(),
+        credential.dedeuserid.as_str(),
+        credential.ac_time_value.as_str(),
+    ];
+    if let Some(value) = credential.buvid4.as_deref() {
+        secrets.push(value);
+    }
+    if let Some(value) = credential.dedeuserid_ckmd5.as_deref() {
+        secrets.push(value);
+    }
+
+    for secret in secrets {
+        let secret = secret.trim();
+        if secret.len() >= 4 {
+            details = details.replace(secret, "***");
+        }
+    }
+
+    details
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/credential/test-refresh",
+    responses(
+        (status = 200, description = "凭据刷新诊断完成", body = CredentialRefreshTestResponse),
+        (status = 500, description = "服务器内部错误", body = String)
+    )
+)]
+pub async fn test_credential_refresh() -> Result<ApiResponse<CredentialRefreshTestResponse>, ApiError> {
+    let config = crate::config::reload_config();
+    let credential = config.credential.load();
+    let credential_fields = credential_field_status(credential.as_deref());
+
+    if !credential_fields.has_credential {
+        return Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+            success: false,
+            message: "未找到 B 站登录凭据".to_string(),
+            stage: "field_check".to_string(),
+            error_type: Some("Configuration".to_string()),
+            should_retry: false,
+            diagnosis: "请先扫码登录或手动填写凭据。".to_string(),
+            details: None,
+            credential_fields,
+        }));
+    }
+
+    if credential_fields.sessdata_len == 0
+        || credential_fields.bili_jct_len == 0
+        || credential_fields.buvid3_len == 0
+        || credential_fields.dedeuserid_len == 0
+    {
+        return Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+            success: false,
+            message: "B 站登录凭据必填字段不完整".to_string(),
+            stage: "field_check".to_string(),
+            error_type: Some("Configuration".to_string()),
+            should_retry: false,
+            diagnosis: "请补齐 SESSDATA、bili_jct、buvid3 和 DedeUserID。".to_string(),
+            details: None,
+            credential_fields,
+        }));
+    }
+
+    if credential_fields.ac_time_value_len == 0 {
+        return Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+            success: false,
+            message: "缺少 ac_time_value，无法测试自动刷新".to_string(),
+            stage: "field_check".to_string(),
+            error_type: Some("Configuration".to_string()),
+            should_retry: false,
+            diagnosis: "自动刷新 Cookie 需要 ac_time_value；请重新扫码登录或更新整套凭据。".to_string(),
+            details: None,
+            credential_fields,
+        }));
+    }
+
+    let bili_client = crate::bilibili::BiliClient::new(String::new());
+    match bili_client.check_refresh().await {
+        Ok(()) => Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+            success: true,
+            message: "B 站凭据检查与自动刷新测试完成".to_string(),
+            stage: "completed".to_string(),
+            error_type: None,
+            should_retry: false,
+            diagnosis: "未复现刷新失败；如果当前 Cookie 不需要刷新，本次只完成刷新状态检查。".to_string(),
+            details: None,
+            credential_fields,
+        })),
+        Err(err) => {
+            let details = format!("{:#}", err);
+            let classified = crate::error::ErrorClassifier::classify_error(&err);
+            let stage = credential_refresh_failure_stage(&details);
+            let diagnosis = credential_refresh_diagnosis(&classified.error_type, &details);
+            let details = redact_credential_refresh_details(details, credential.as_deref());
+            Ok(ApiResponse::ok(CredentialRefreshTestResponse {
+                success: false,
+                message: "B 站凭据检查或自动刷新测试失败".to_string(),
+                stage,
+                error_type: Some(format!("{:?}", classified.error_type)),
+                should_retry: classified.should_retry,
+                diagnosis,
+                details: Some(details),
+                credential_fields,
+            }))
+        }
+    }
 }
 
 /// 生成扫码登录二维码

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -454,6 +454,12 @@ pub struct UpdateCredentialRequest {
     pub dedeuserid_ckmd5: Option<String>,
 }
 
+#[derive(Deserialize, ToSchema, Default)]
+pub struct CredentialRefreshTestRequest {
+    #[serde(default)]
+    pub force: bool,
+}
+
 // 扫码登录相关请求
 
 // 生成二维码请求

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -784,6 +784,30 @@ pub struct UpdateCredentialResponse {
     pub message: String,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct CredentialFieldStatus {
+    pub has_credential: bool,
+    pub sessdata_len: usize,
+    pub bili_jct_len: usize,
+    pub buvid3_len: usize,
+    pub dedeuserid_len: usize,
+    pub ac_time_value_len: usize,
+    pub has_buvid4: bool,
+    pub has_dedeuserid_ckmd5: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct CredentialRefreshTestResponse {
+    pub success: bool,
+    pub message: String,
+    pub stage: String,
+    pub error_type: Option<String>,
+    pub should_retry: bool,
+    pub diagnosis: String,
+    pub details: Option<String>,
+    pub credential_fields: CredentialFieldStatus,
+}
+
 // 扫码登录相关响应
 
 // 生成二维码响应

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -668,6 +668,7 @@ pub struct SearchResponse {
     pub success: bool,
     pub results: Vec<SearchResult>,
     pub total: u32,
+    pub num_pages: u32,
     pub page: u32,
     pub page_size: u32,
 }

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -181,12 +181,45 @@ fn response_body_preview(text: &str) -> String {
         .replace('\n', " ")
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SearchCredentialState {
+    Missing,
+    Incomplete,
+    Complete,
+}
+
+fn current_search_credential_state() -> SearchCredentialState {
+    let config = crate::config::reload_config();
+    let credential = config.credential.load();
+    match credential.as_deref() {
+        Some(credential)
+            if !credential.sessdata.trim().is_empty()
+                && !credential.buvid3.trim().is_empty()
+                && !credential.dedeuserid.trim().is_empty() =>
+        {
+            SearchCredentialState::Complete
+        }
+        Some(_) => SearchCredentialState::Incomplete,
+        None => SearchCredentialState::Missing,
+    }
+}
+
 fn search_http_status_message(operation: &str, status: StatusCode) -> String {
     if status == StatusCode::PRECONDITION_FAILED {
-        format!(
-            "{}触发 B 站风控(412)：请求被安全策略拒绝；搜索请求需要带稳定 Cookie/buvid 指纹，请先配置 B 站凭据，并确认 Referer 来自搜索页，避免无痕/新环境或出口 IP 风控",
-            operation
-        )
+        match current_search_credential_state() {
+            SearchCredentialState::Complete => format!(
+                "{}触发 B 站风控(412)：程序已携带当前配置的 Cookie/buvid 指纹并使用搜索页 Referer，但仍被 B 站安全策略拒绝；请稍后重试，或检查这套凭据/出口 IP 是否已被风控",
+                operation
+            ),
+            SearchCredentialState::Incomplete => format!(
+                "{}触发 B 站风控(412)：当前 B 站凭据缺少 SESSDATA、buvid3 或 DedeUserID，搜索请求无法形成稳定 Cookie/buvid 指纹；请重新扫码或补齐整套凭据",
+                operation
+            ),
+            SearchCredentialState::Missing => format!(
+                "{}触发 B 站风控(412)：当前未配置 B 站凭据，搜索请求无法携带 Cookie/buvid 指纹；请先扫码配置 B 站凭据后再试",
+                operation
+            ),
+        }
     } else {
         format!("{}请求失败: {}", operation, status)
     }

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -316,37 +316,44 @@ impl BiliClient {
     }
 
     pub async fn check_refresh(&self) -> Result<()> {
+        self.refresh_credential(false).await.map(|_| ())
+    }
+
+    pub async fn refresh_credential(&self, force: bool) -> Result<bool> {
         let config = crate::config::reload_config();
         let credential = config.credential.load();
         let Some(credential) = credential.as_deref() else {
-            return Ok(());
+            return Ok(false);
         };
 
-        let should_refresh = match credential.need_refresh(&self.client).await {
-            Ok(need_refresh) => need_refresh,
+        let refresh_info = match credential.refresh_info(&self.client).await {
+            Ok(refresh_info) => refresh_info,
             Err(err) => {
                 let error_text = format!("{:#}", err);
                 let is_login_expired = error_text.contains("status code: -101") || error_text.contains("账号未登录");
                 if is_login_expired && !credential.ac_time_value.trim().is_empty() {
                     warn!("检测到凭证已过期，跳过预检查并直接尝试刷新凭证");
-                    true
+                    crate::bilibili::credential::CookieRefreshInfo {
+                        need_refresh: true,
+                        timestamp: None,
+                    }
                 } else {
                     return Err(err);
                 }
             }
         };
 
-        if !should_refresh {
-            return Ok(());
+        if !force && !refresh_info.need_refresh {
+            return Ok(false);
         }
 
-        let new_credential = credential.refresh(&self.client).await?;
+        let new_credential = credential.refresh(&self.client, refresh_info.timestamp).await?;
         config.credential.store(Some(Arc::new(new_credential.clone())));
 
         self.persist_refreshed_credential(&config).await?;
         info!("credential已刷新并保存到数据库");
 
-        Ok(())
+        Ok(true)
     }
 
     async fn persist_refreshed_credential(&self, config: &crate::config::Config) -> Result<()> {

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -423,7 +423,13 @@ impl BiliClient {
             ("tids", "0"),          // 不限分区
         ];
 
-        let response = self.request(Method::GET, url).await.query(&params).send().await?;
+        let response = self
+            .request(Method::GET, url)
+            .await
+            .header(header::REFERER, "https://search.bilibili.com/")
+            .query(&params)
+            .send()
+            .await?;
 
         if !response.status().is_success() {
             // 旧搜索接口在部分环境会返回 412，回退到 all/v2 接口以保证可用性
@@ -489,6 +495,7 @@ impl BiliClient {
         let response = self
             .request(Method::GET, url)
             .await
+            .header(header::REFERER, "https://search.bilibili.com/")
             .query(&signed_params)
             .send()
             .await?;
@@ -552,7 +559,13 @@ impl BiliClient {
             ("page_size", &page_size.to_string()),
         ];
 
-        let response = self.request(Method::GET, url).await.query(&params).send().await?;
+        let response = self
+            .request(Method::GET, url)
+            .await
+            .header(header::REFERER, "https://search.bilibili.com/")
+            .query(&params)
+            .send()
+            .await?;
         if !response.status().is_success() {
             return Err(anyhow!("all/v2 搜索请求失败: {}", response.status()));
         }

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -172,6 +172,43 @@ impl Default for Client {
     }
 }
 
+fn response_body_preview(text: &str) -> String {
+    text.chars()
+        .take(200)
+        .collect::<String>()
+        .replace('\r', " ")
+        .replace('\n', " ")
+}
+
+async fn decode_json_response<T>(response: reqwest::Response, operation: &str) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("unknown")
+        .to_string();
+    let body = response.text().await.with_context(|| {
+        format!(
+            "读取{}响应体失败: status={}, content-type={}",
+            operation, status, content_type
+        )
+    })?;
+
+    serde_json::from_str(&body).with_context(|| {
+        format!(
+            "{}响应不是有效 JSON: status={}, content-type={}, body_prefix={}",
+            operation,
+            status,
+            content_type,
+            response_body_preview(&body)
+        )
+    })
+}
+
 #[derive(Clone)]
 pub struct BiliClient {
     pub client: Client,
@@ -370,7 +407,16 @@ impl BiliClient {
             return Err(anyhow!("搜索请求失败: {}", response.status()));
         }
 
-        let search_response: SearchResponse = response.json().await?;
+        let search_response: SearchResponse = match decode_json_response(response, "搜索").await {
+            Ok(search_response) => search_response,
+            Err(err) => {
+                warn!("旧搜索接口响应解析失败，回退到 all/v2 搜索接口: {:#}", err);
+                return self
+                    .search_via_all_v2(keyword, search_type, page, page_size)
+                    .await
+                    .with_context(|| format!("旧搜索接口响应解析失败且 all/v2 回退失败: {:#}", err));
+            }
+        };
 
         if search_response.code != 0 {
             return Err(anyhow!("搜索API返回错误: {}", search_response.message));
@@ -432,7 +478,7 @@ impl BiliClient {
             return Err(anyhow!("all/v2 搜索请求失败: {}", response.status()));
         }
 
-        let payload = response.json::<serde_json::Value>().await?;
+        let payload: serde_json::Value = decode_json_response(response, "all/v2 搜索").await?;
         let code = payload["code"].as_i64().unwrap_or(-1);
         if code != 0 {
             let msg = payload["message"].as_str().unwrap_or("unknown");

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -181,6 +181,17 @@ fn response_body_preview(text: &str) -> String {
         .replace('\n', " ")
 }
 
+fn search_http_status_message(operation: &str, status: StatusCode) -> String {
+    if status == StatusCode::PRECONDITION_FAILED {
+        format!(
+            "{}触发 B 站风控(412)：请求被安全策略拒绝；搜索请求需要带稳定 Cookie/buvid 指纹，请先配置 B 站凭据，并确认 Referer 来自搜索页，避免无痕/新环境或出口 IP 风控",
+            operation
+        )
+    } else {
+        format!("{}请求失败: {}", operation, status)
+    }
+}
+
 async fn decode_json_response<T>(response: reqwest::Response, operation: &str) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
@@ -437,7 +448,7 @@ impl BiliClient {
                 warn!("旧搜索接口触发412，回退到all/v2搜索接口");
                 return self.search_via_all_v2(keyword, search_type, page, page_size).await;
             }
-            return Err(anyhow!("搜索请求失败: {}", response.status()));
+            return Err(anyhow!(search_http_status_message("旧搜索接口", response.status())));
         }
 
         let search_response: SearchResponse = match decode_json_response(response, "搜索").await {
@@ -501,7 +512,7 @@ impl BiliClient {
             .await?;
 
         if !response.status().is_success() {
-            return Err(anyhow!("WBI 搜索请求失败: {}", response.status()));
+            return Err(anyhow!(search_http_status_message("WBI 搜索接口", response.status())));
         }
 
         let search_response: SearchResponse = decode_json_response(response, "WBI 搜索").await?;
@@ -567,7 +578,10 @@ impl BiliClient {
             .send()
             .await?;
         if !response.status().is_success() {
-            return Err(anyhow!("all/v2 搜索请求失败: {}", response.status()));
+            return Err(anyhow!(search_http_status_message(
+                "all/v2 搜索接口",
+                response.status()
+            )));
         }
 
         let payload: serde_json::Value = decode_json_response(response, "all/v2 搜索").await?;

--- a/crates/bili_sync/src/bilibili/client.rs
+++ b/crates/bili_sync/src/bilibili/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -373,8 +374,20 @@ impl BiliClient {
     pub async fn wbi_img(&self) -> Result<WbiImg> {
         let config = crate::config::reload_config();
         let credential = config.credential.load();
-        let credential = credential.as_deref().context("no credential found")?;
-        credential.wbi_img(&self.client).await
+        let mut res = self
+            .client
+            .request(
+                Method::GET,
+                "https://api.bilibili.com/x/web-interface/nav",
+                credential.as_deref(),
+            )
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<serde_json::Value>()
+            .await?
+            .validate()?;
+        Ok(serde_json::from_value(res["data"]["wbi_img"].take())?)
     }
 
     /// 搜索bilibili内容
@@ -391,6 +404,13 @@ impl BiliClient {
         page: u32,
         page_size: u32,
     ) -> Result<SearchResponseWrapper> {
+        match self.search_via_wbi_type(keyword, search_type, page, page_size).await {
+            Ok(wrapper) => return Ok(wrapper),
+            Err(err) => {
+                warn!("WBI 搜索接口失败，回退旧搜索接口: {:#}", err);
+            }
+        }
+
         let url = "https://api.bilibili.com/x/web-interface/search/type";
 
         let params = [
@@ -425,6 +445,68 @@ impl BiliClient {
             }
         };
 
+        self.parse_typed_search_response(search_response, search_type, page_size)
+    }
+
+    /// 使用 B 站 Web 端实际调用的 WBI 搜索接口。
+    async fn search_via_wbi_type(
+        &self,
+        keyword: &str,
+        search_type: &str,
+        page: u32,
+        page_size: u32,
+    ) -> Result<SearchResponseWrapper> {
+        let url = "https://api.bilibili.com/x/web-interface/wbi/search/type";
+        let wbi_img = self.wbi_img().await.context("获取 WBI 签名参数失败")?;
+        let params = HashMap::from([
+            ("category_id".to_string(), String::new()),
+            ("search_type".to_string(), search_type.to_string()),
+            ("ad_resource".to_string(), "5646".to_string()),
+            ("__refresh__".to_string(), "true".to_string()),
+            ("_extra".to_string(), String::new()),
+            ("context".to_string(), String::new()),
+            ("page".to_string(), page.to_string()),
+            ("page_size".to_string(), page_size.to_string()),
+            ("order".to_string(), String::new()),
+            ("pubtime_begin_s".to_string(), "0".to_string()),
+            ("pubtime_end_s".to_string(), "0".to_string()),
+            ("duration".to_string(), String::new()),
+            ("from_source".to_string(), String::new()),
+            ("from_spmid".to_string(), "333.337".to_string()),
+            ("platform".to_string(), "pc".to_string()),
+            ("highlight".to_string(), "1".to_string()),
+            ("single_column".to_string(), "0".to_string()),
+            ("keyword".to_string(), keyword.to_string()),
+            ("source_tag".to_string(), "3".to_string()),
+            ("gaia_vtoken".to_string(), String::new()),
+            ("order_sort".to_string(), "0".to_string()),
+            ("user_type".to_string(), "0".to_string()),
+            ("dynamic_offset".to_string(), "0".to_string()),
+            ("web_location".to_string(), "1430654".to_string()),
+        ]);
+        let signed_params = wbi_img.sign_params(params).await.context("生成搜索 WBI 签名失败")?;
+
+        let response = self
+            .request(Method::GET, url)
+            .await
+            .query(&signed_params)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!("WBI 搜索请求失败: {}", response.status()));
+        }
+
+        let search_response: SearchResponse = decode_json_response(response, "WBI 搜索").await?;
+        self.parse_typed_search_response(search_response, search_type, page_size)
+    }
+
+    fn parse_typed_search_response(
+        &self,
+        search_response: SearchResponse,
+        search_type: &str,
+        page_size: u32,
+    ) -> Result<SearchResponseWrapper> {
         if search_response.code != 0 {
             return Err(anyhow!("搜索API返回错误: {}", search_response.message));
         }
@@ -434,22 +516,12 @@ impl BiliClient {
             num_pages: None,
             num_results: None,
         });
-
         let results = data.result.unwrap_or_default();
-
-        // 获取总数和页数
         let total = data.num_results.unwrap_or(0) as u32;
-        let num_pages = data.num_pages.unwrap_or(0) as u32;
-        let num_pages = if num_pages == 0 {
-            if total > 0 {
-                total.div_ceil(page_size) // 向上取整
-            } else {
-                1
-            }
-        } else {
-            num_pages
-        };
-
+        let mut num_pages = data.num_pages.unwrap_or(0) as u32;
+        if num_pages == 0 {
+            num_pages = if total > 0 { total.div_ceil(page_size) } else { 1 };
+        }
         let mut parsed_results = Vec::new();
 
         for item in results {

--- a/crates/bili_sync/src/bilibili/credential.rs
+++ b/crates/bili_sync/src/bilibili/credential.rs
@@ -73,18 +73,6 @@ impl WbiImg {
 }
 
 impl Credential {
-    pub async fn wbi_img(&self, client: &Client) -> Result<WbiImg> {
-        let mut res = client
-            .request(Method::GET, "https://api.bilibili.com/x/web-interface/nav", Some(self))
-            .send()
-            .await?
-            .error_for_status()?
-            .json::<serde_json::Value>()
-            .await?
-            .validate()?;
-        Ok(serde_json::from_value(res["data"]["wbi_img"].take())?)
-    }
-
     /// 检查凭据是否有效
     pub async fn refresh_info(&self, client: &Client) -> Result<CookieRefreshInfo> {
         let res = client

--- a/crates/bili_sync/src/bilibili/credential.rs
+++ b/crates/bili_sync/src/bilibili/credential.rs
@@ -13,6 +13,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::bilibili::{Client, Validate};
 
+pub struct CookieRefreshInfo {
+    pub need_refresh: bool,
+    pub timestamp: Option<i64>,
+}
+
 const MIXIN_KEY_ENC_TAB: [usize; 64] = [
     46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39, 12, 38,
     41, 13, 37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 54, 21, 56, 59, 6, 63, 57, 62, 11, 36,
@@ -81,7 +86,7 @@ impl Credential {
     }
 
     /// 检查凭据是否有效
-    pub async fn need_refresh(&self, client: &Client) -> Result<bool> {
+    pub async fn refresh_info(&self, client: &Client) -> Result<CookieRefreshInfo> {
         let res = client
             .request(
                 Method::GET,
@@ -94,12 +99,15 @@ impl Credential {
             .json::<serde_json::Value>()
             .await?
             .validate()?;
-        res["data"]["refresh"].as_bool().context("check refresh failed")
+        Ok(CookieRefreshInfo {
+            need_refresh: res["data"]["refresh"].as_bool().context("check refresh failed")?,
+            timestamp: res["data"]["timestamp"].as_i64(),
+        })
     }
 
-    pub async fn refresh(&self, client: &Client) -> Result<Self> {
+    pub async fn refresh(&self, client: &Client, timestamp: Option<i64>) -> Result<Self> {
         self.ensure_can_refresh()?;
-        let correspond_path = Self::get_correspond_path();
+        let correspond_path = Self::get_correspond_path(timestamp);
         let csrf = self.get_refresh_csrf(client, correspond_path).await.context(
             "获取B站 Cookie 刷新 csrf 失败，可能是旧 Cookie 已失效、被手动退出登录，或和 ac_time_value 不匹配",
         )?;
@@ -129,7 +137,7 @@ impl Credential {
         Ok(())
     }
 
-    fn get_correspond_path() -> String {
+    fn get_correspond_path(timestamp: Option<i64>) -> String {
         // 调用频率很低，让 key 在函数内部构造影响不大
         let key = RsaPublicKey::from_public_key_pem(
             "-----BEGIN PUBLIC KEY-----
@@ -140,8 +148,8 @@ JNrRuoEUXpabUzGB8QIDAQAB
 -----END PUBLIC KEY-----",
         )
         .expect("fail to decode public key");
-        // B站会校验 correspondPath 内的时间戳；本机时间略快时可能拿不到 refresh_csrf。
-        let ts = chrono::Local::now().timestamp_millis() - 20000;
+        // B站会校验 correspondPath 内的时间戳；优先使用 cookie/info 返回的服务端时间。
+        let ts = timestamp.unwrap_or_else(|| chrono::Local::now().timestamp_millis() - 20000);
         let data = format!("refresh_{}", ts).into_bytes();
         let mut rng = rand::rngs::OsRng;
         let encrypted = key

--- a/crates/bili_sync/src/task/http_server.rs
+++ b/crates/bili_sync/src/task/http_server.rs
@@ -80,6 +80,7 @@ use crate::api::handler::{
     stream_queue_status,
     stream_video_sources,
     stream_videos,
+    test_credential_refresh,
     test_notification_handler,
     test_risk_control_handler,
     update_config,
@@ -250,6 +251,7 @@ pub async fn http_server(_database_connection: Arc<DatabaseConnection>) -> Resul
         .route("/api/setup/check", get(check_initial_setup))
         .route("/api/setup/auth-token", post(setup_auth_token))
         .route("/api/credential", put(update_credential))
+        .route("/api/credential/test-refresh", post(test_credential_refresh))
         // 扫码登录API路由
         .route("/api/auth/qr/generate", post(generate_qr_code))
         .route("/api/auth/qr/poll", get(poll_qr_status))

--- a/crates/bili_sync/src/task/video_downloader.rs
+++ b/crates/bili_sync/src/task/video_downloader.rs
@@ -29,6 +29,9 @@ const DAILY_CREDENTIAL_REFRESH_HOUR: u32 = 1;
 const LOGIN_EXPIRED_NOTIFICATION_TITLE: &str = "B站登录状态异常";
 const LOGIN_EXPIRED_NOTIFICATION_MESSAGE: &str =
     "检测到B站登录状态过期或未登录，自动刷新 Cookie 失败；请重新扫码登录或更新整套认证信息（SESSDATA、bili_jct、DedeUserID、ac_time_value）";
+const CREDENTIAL_REFRESH_NETWORK_NOTIFICATION_TITLE: &str = "B站凭据自动刷新暂时失败";
+const CREDENTIAL_REFRESH_NETWORK_NOTIFICATION_MESSAGE: &str =
+    "每日B站凭据检查时网络请求失败，暂时无法确认登录状态；本次不要求重新扫码，下一次会继续自动检查";
 
 fn is_submission_lookup_retryable_error(err: &anyhow::Error) -> bool {
     matches!(
@@ -77,6 +80,31 @@ fn is_wbi_fetch_retryable_error(err: &anyhow::Error) -> bool {
         crate::error::ErrorClassifier::classify_error(err).error_type,
         crate::error::ErrorType::Network | crate::error::ErrorType::Timeout | crate::error::ErrorType::ServerError
     )
+}
+
+fn is_credential_refresh_transient_error(err: &anyhow::Error) -> bool {
+    if is_wbi_login_expired_error(err) {
+        return false;
+    }
+
+    if matches!(
+        crate::error::ErrorClassifier::classify_error(err).error_type,
+        crate::error::ErrorType::Network
+            | crate::error::ErrorType::Timeout
+            | crate::error::ErrorType::RateLimit
+            | crate::error::ErrorType::ServerError
+    ) {
+        return true;
+    }
+
+    let error_text = format!("{:#}", err).to_lowercase();
+    error_text.contains("error sending request")
+        || error_text.contains("tcp connect error")
+        || error_text.contains("address not available")
+        || error_text.contains("connection refused")
+        || error_text.contains("network")
+        || error_text.contains("timed out")
+        || error_text.contains("timeout")
 }
 
 async fn fetch_wbi_mixin_key_with_retry(bili_client: &BiliClient) -> Result<Option<String>> {
@@ -217,6 +245,19 @@ async fn record_login_expired_warning(message: &str, context: Option<&str>) {
     send_source_status_notification(LOGIN_EXPIRED_NOTIFICATION_TITLE, message, context).await;
 }
 
+async fn record_credential_refresh_network_warning(context: Option<&str>) {
+    add_video_downloader_log_entry(
+        crate::api::handler::LogLevel::Warn,
+        CREDENTIAL_REFRESH_NETWORK_NOTIFICATION_MESSAGE,
+    );
+    send_source_status_notification(
+        CREDENTIAL_REFRESH_NETWORK_NOTIFICATION_TITLE,
+        CREDENTIAL_REFRESH_NETWORK_NOTIFICATION_MESSAGE,
+        context,
+    )
+    .await;
+}
+
 fn next_daily_credential_refresh_after(now: NaiveDateTime) -> NaiveDateTime {
     let refresh_time = NaiveTime::from_hms_opt(DAILY_CREDENTIAL_REFRESH_HOUR, 0, 0).unwrap();
     let today_refresh = NaiveDateTime::new(now.date(), refresh_time);
@@ -249,9 +290,14 @@ pub async fn credential_refresh_scheduler() {
         match bili_client.check_refresh().await {
             Ok(()) => info!("每日B站凭据检查与自动刷新任务执行完毕"),
             Err(err) => {
-                warn!("每日B站凭据检查与自动刷新任务失败: {:#}", err);
                 let context = format!("每日自动刷新失败: {:#}", err);
-                record_login_expired_warning(LOGIN_EXPIRED_NOTIFICATION_MESSAGE, Some(context.as_str())).await;
+                if is_credential_refresh_transient_error(&err) {
+                    warn!("每日B站凭据检查与自动刷新任务暂时失败: {:#}", err);
+                    record_credential_refresh_network_warning(Some(context.as_str())).await;
+                } else {
+                    warn!("每日B站凭据检查与自动刷新任务失败: {:#}", err);
+                    record_login_expired_warning(LOGIN_EXPIRED_NOTIFICATION_MESSAGE, Some(context.as_str())).await;
+                }
             }
         }
     }
@@ -1422,6 +1468,16 @@ mod tests {
     #[test]
     fn wbi_login_expired_error_detects_missing_credential() {
         assert!(is_wbi_login_expired_error(&anyhow::anyhow!("no credential found")));
+    }
+
+    #[test]
+    fn credential_refresh_transient_error_detects_network_failures() {
+        assert!(is_credential_refresh_transient_error(&anyhow::anyhow!(
+            "请求B站 Cookie 刷新 csrf 页面失败: error sending request: client error (Connect): tcp connect error: Address not available (os error 99)"
+        )));
+        assert!(!is_credential_refresh_transient_error(&anyhow::anyhow!(
+            "Bilibili api error, status code: -101"
+        )));
     }
 
     #[test]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
 	ValidateRegexResponse,
 	UpdateCredentialRequest,
 	UpdateCredentialResponse,
+	CredentialRefreshTestResponse,
 	InitialSetupCheckResponse,
 	TaskControlStatusResponse,
 	TaskControlResponse,
@@ -738,6 +739,10 @@ class ApiClient {
 		return this.put<UpdateCredentialResponse>('/credential', params);
 	}
 
+	async testCredentialRefresh(): Promise<ApiResponse<CredentialRefreshTestResponse>> {
+		return this.post<CredentialRefreshTestResponse>('/credential/test-refresh');
+	}
+
 	/**
 	 * 设置API Token（初始设置时使用）
 	 * @param token API Token
@@ -1270,6 +1275,8 @@ export const api = {
 	 * 更新B站登录凭证
 	 */
 	updateCredential: (params: UpdateCredentialRequest) => apiClient.updateCredential(params),
+
+	testCredentialRefresh: () => apiClient.testCredentialRefresh(),
 
 	/**
 	 * 设置API Token（初始设置时使用）

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
 	ValidateRegexResponse,
 	UpdateCredentialRequest,
 	UpdateCredentialResponse,
+	CredentialRefreshTestRequest,
 	CredentialRefreshTestResponse,
 	InitialSetupCheckResponse,
 	TaskControlStatusResponse,
@@ -739,8 +740,9 @@ class ApiClient {
 		return this.put<UpdateCredentialResponse>('/credential', params);
 	}
 
-	async testCredentialRefresh(): Promise<ApiResponse<CredentialRefreshTestResponse>> {
-		return this.post<CredentialRefreshTestResponse>('/credential/test-refresh');
+	async testCredentialRefresh(force = false): Promise<ApiResponse<CredentialRefreshTestResponse>> {
+		const request: CredentialRefreshTestRequest = { force };
+		return this.post<CredentialRefreshTestResponse>('/credential/test-refresh', request);
 	}
 
 	/**
@@ -1276,7 +1278,7 @@ export const api = {
 	 */
 	updateCredential: (params: UpdateCredentialRequest) => apiClient.updateCredential(params),
 
-	testCredentialRefresh: () => apiClient.testCredentialRefresh(),
+	testCredentialRefresh: (force = false) => apiClient.testCredentialRefresh(force),
 
 	/**
 	 * 设置API Token（初始设置时使用）

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -881,6 +881,10 @@ export interface CredentialFieldStatus {
 	has_dedeuserid_ckmd5: boolean;
 }
 
+export interface CredentialRefreshTestRequest {
+	force?: boolean;
+}
+
 export interface CredentialRefreshTestResponse {
 	success: boolean;
 	message: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -870,6 +870,28 @@ export interface UpdateCredentialResponse {
 	message: string;
 }
 
+export interface CredentialFieldStatus {
+	has_credential: boolean;
+	sessdata_len: number;
+	bili_jct_len: number;
+	buvid3_len: number;
+	dedeuserid_len: number;
+	ac_time_value_len: number;
+	has_buvid4: boolean;
+	has_dedeuserid_ckmd5: boolean;
+}
+
+export interface CredentialRefreshTestResponse {
+	success: boolean;
+	message: string;
+	stage: string;
+	error_type?: string | null;
+	should_retry: boolean;
+	diagnosis: string;
+	details?: string | null;
+	credential_fields: CredentialFieldStatus;
+}
+
 // 初始设置检查响应类型
 export interface InitialSetupCheckResponse {
 	needs_setup: boolean;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -574,6 +574,7 @@ export interface SearchResponse {
 	success: boolean;
 	results: SearchResultItem[];
 	total: number;
+	num_pages: number;
 	page: number;
 	page_size: number;
 }

--- a/web/src/routes/add-source/+page.svelte
+++ b/web/src/routes/add-source/+page.svelte
@@ -461,7 +461,7 @@
 
 				// 如果总数超过pageSize，继续获取剩余页面
 				if (totalResults > pageSize) {
-					const totalPages = Math.ceil(totalResults / pageSize);
+					const totalPages = firstResult.data.num_pages || Math.ceil(totalResults / pageSize);
 					const remainingPages = Array.from({ length: totalPages - 1 }, (_, i) => i + 2);
 
 					// 串行获取剩余页面，避免并发请求过多导致失败

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -12,7 +12,12 @@
 	import ResponsiveSheet from '$lib/components/responsive-sheet.svelte';
 	import SectionHeader from '$lib/components/section-header.svelte';
 	import { setBreadcrumb } from '$lib/stores/breadcrumb';
-	import type { ConfigResponse, UserInfo, UpdateConfigRequest } from '$lib/types';
+	import type {
+		ConfigResponse,
+		CredentialRefreshTestResponse,
+		UserInfo,
+		UpdateConfigRequest
+	} from '$lib/types';
 	import {
 		DownloadIcon,
 		FileTextIcon,
@@ -24,7 +29,8 @@
 		VideoIcon,
 		PaletteIcon,
 		BellIcon,
-		SparklesIcon
+		SparklesIcon,
+		RefreshCwIcon
 	} from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
@@ -283,6 +289,8 @@
 	let buvid4 = '';
 	let dedeUserIdCkMd5 = '';
 	let credentialSaving = false;
+	let credentialRefreshTesting = false;
+	let credentialRefreshTestResult: CredentialRefreshTestResponse | null = null;
 	let currentUser: UserInfo | null = null;
 
 	// UP主投稿风控配置
@@ -1126,6 +1134,21 @@
 			openSheet = null; // 关闭抽屉
 		} else {
 			toast.error('保存失败', { description: response.data.message });
+		}
+	}
+
+	async function testCredentialRefresh() {
+		const response = await runRequest(() => api.testCredentialRefresh(), {
+			setLoading: (value) => (credentialRefreshTesting = value),
+			context: '测试B站凭据刷新失败'
+		});
+		if (!response) return;
+
+		credentialRefreshTestResult = response.data;
+		if (response.data.success) {
+			toast.success('凭据刷新测试通过', { description: response.data.message });
+		} else {
+			toast.error('凭据刷新测试失败', { description: response.data.diagnosis });
 		}
 	}
 
@@ -2680,6 +2703,106 @@
 									{/if}
 								</div>
 							</div>
+						</div>
+
+						<div
+							class="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-950/30"
+						>
+							<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+								<div>
+									<div class="text-sm font-medium text-slate-900 dark:text-slate-100">
+										自动刷新诊断
+									</div>
+									<div class="text-xs text-slate-600 dark:text-slate-400">
+										字段长度、错误阶段、错误类型。
+									</div>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onclick={testCredentialRefresh}
+									disabled={credentialRefreshTesting}
+									class="w-full sm:w-auto"
+								>
+									<RefreshCwIcon class={credentialRefreshTesting ? 'animate-spin' : ''} />
+									{credentialRefreshTesting ? '测试中...' : '测试刷新'}
+								</Button>
+							</div>
+
+							{#if credentialRefreshTestResult}
+								<div
+									class={`rounded-md border p-3 ${
+										credentialRefreshTestResult.success
+											? 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20'
+											: 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/20'
+									}`}
+								>
+									<div class="mb-2 flex flex-wrap items-center gap-2">
+										<Badge
+											variant={credentialRefreshTestResult.success ? 'default' : 'secondary'}
+											class={credentialRefreshTestResult.success
+												? 'bg-green-600 text-white'
+												: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-100'}
+										>
+											{credentialRefreshTestResult.success ? '通过' : '失败'}
+										</Badge>
+										<span class="text-sm font-medium text-slate-900 dark:text-slate-100">
+											{credentialRefreshTestResult.message}
+										</span>
+									</div>
+
+									<div
+										class="grid grid-cols-1 gap-2 text-xs text-slate-700 sm:grid-cols-2 dark:text-slate-300"
+									>
+										<div>阶段：{credentialRefreshTestResult.stage}</div>
+										<div>类型：{credentialRefreshTestResult.error_type ?? '无'}</div>
+										<div>建议重试：{credentialRefreshTestResult.should_retry ? '是' : '否'}</div>
+										<div>
+											凭据：{credentialRefreshTestResult.credential_fields.has_credential
+												? '已加载'
+												: '未加载'}
+										</div>
+									</div>
+
+									<div class="mt-2 text-xs text-slate-700 dark:text-slate-300">
+										{credentialRefreshTestResult.diagnosis}
+									</div>
+
+									<div class="mt-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+										<div class="rounded border bg-background px-2 py-1">
+											SESSDATA：{credentialRefreshTestResult.credential_fields.sessdata_len}
+										</div>
+										<div class="rounded border bg-background px-2 py-1">
+											bili_jct：{credentialRefreshTestResult.credential_fields.bili_jct_len}
+										</div>
+										<div class="rounded border bg-background px-2 py-1">
+											buvid3：{credentialRefreshTestResult.credential_fields.buvid3_len}
+										</div>
+										<div class="rounded border bg-background px-2 py-1">
+											DedeUserID：{credentialRefreshTestResult.credential_fields.dedeuserid_len}
+										</div>
+										<div class="rounded border bg-background px-2 py-1">
+											ac_time_value：{credentialRefreshTestResult.credential_fields.ac_time_value_len}
+										</div>
+										<div class="rounded border bg-background px-2 py-1">
+											buvid4：{credentialRefreshTestResult.credential_fields.has_buvid4 ? '有' : '无'}
+										</div>
+										<div class="rounded border bg-background px-2 py-1 sm:col-span-2">
+											DedeUserID__ckMd5：{credentialRefreshTestResult.credential_fields
+												.has_dedeuserid_ckmd5
+												? '有'
+												: '无'}
+										</div>
+									</div>
+
+									{#if credentialRefreshTestResult.details}
+										<pre
+											class="mt-3 max-h-36 overflow-auto whitespace-pre-wrap rounded border bg-background p-2 text-xs text-slate-700 dark:text-slate-300"
+										>{credentialRefreshTestResult.details}</pre>
+									{/if}
+								</div>
+							{/if}
 						</div>
 					</div>
 					<SheetFooter class={isMobile ? 'pb-safe border-t px-4 pt-3' : 'pb-safe border-t pt-4'}>

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -290,6 +290,7 @@
 	let dedeUserIdCkMd5 = '';
 	let credentialSaving = false;
 	let credentialRefreshTesting = false;
+	let credentialRefreshForceTesting = false;
 	let credentialRefreshTestResult: CredentialRefreshTestResponse | null = null;
 	let currentUser: UserInfo | null = null;
 
@@ -1137,18 +1138,24 @@
 		}
 	}
 
-	async function testCredentialRefresh() {
-		const response = await runRequest(() => api.testCredentialRefresh(), {
-			setLoading: (value) => (credentialRefreshTesting = value),
-			context: '测试B站凭据刷新失败'
+	async function testCredentialRefresh(force = false) {
+		const response = await runRequest(() => api.testCredentialRefresh(force), {
+			setLoading: (value) =>
+				force ? (credentialRefreshForceTesting = value) : (credentialRefreshTesting = value),
+			context: force ? '强制刷新B站凭据失败' : '测试B站凭据刷新失败'
 		});
 		if (!response) return;
 
 		credentialRefreshTestResult = response.data;
 		if (response.data.success) {
-			toast.success('凭据刷新测试通过', { description: response.data.message });
+			toast.success(force ? '凭据强制刷新完成' : '凭据刷新测试通过', {
+				description: response.data.message
+			});
+			if (force) await loadConfig();
 		} else {
-			toast.error('凭据刷新测试失败', { description: response.data.diagnosis });
+			toast.error(force ? '凭据强制刷新失败' : '凭据刷新测试失败', {
+				description: response.data.diagnosis
+			});
 		}
 	}
 
@@ -2717,17 +2724,30 @@
 										字段长度、错误阶段、错误类型。
 									</div>
 								</div>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onclick={testCredentialRefresh}
-									disabled={credentialRefreshTesting}
-									class="w-full sm:w-auto"
-								>
-									<RefreshCwIcon class={credentialRefreshTesting ? 'animate-spin' : ''} />
-									{credentialRefreshTesting ? '测试中...' : '测试刷新'}
-								</Button>
+								<div class="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onclick={() => testCredentialRefresh(false)}
+										disabled={credentialRefreshTesting || credentialRefreshForceTesting}
+										class="w-full sm:w-auto"
+									>
+										<RefreshCwIcon class={credentialRefreshTesting ? 'animate-spin' : ''} />
+										{credentialRefreshTesting ? '测试中...' : '测试刷新'}
+									</Button>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onclick={() => testCredentialRefresh(true)}
+										disabled={credentialRefreshTesting || credentialRefreshForceTesting}
+										class="w-full border-amber-300 text-amber-700 hover:bg-amber-50 sm:w-auto dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-950/30"
+									>
+										<RefreshCwIcon class={credentialRefreshForceTesting ? 'animate-spin' : ''} />
+										{credentialRefreshForceTesting ? '强刷中...' : '强制刷新'}
+									</Button>
+								</div>
 							</div>
 
 							{#if credentialRefreshTestResult}


### PR DESCRIPTION
﻿## 改动
- 将每日 B 站凭据刷新失败拆分为网络临时失败和登录/凭据失效两类。
- 网络、超时、服务端临时错误不再提示重新扫码，改为提示“凭据自动刷新暂时失败”。
- 刷新流程使用 `cookie/info` 返回的服务端 `timestamp` 生成 `correspondPath`，降低本机时间偏差导致拿不到 `refresh_csrf` 的概率。
- 搜索接口响应解析失败时先回退 all/v2，并在最终失败时带上状态码、Content-Type 和响应前缀。
- 搜索优先使用 B 站 Web 端实际调用的 `/x/web-interface/wbi/search/type`，带 WBI 签名，避免旧 `/search/type` 在部分环境不稳定。
- 搜索请求显式使用 `Referer: https://search.bilibili.com/`；三个搜索分支都通过 `self.request()` 读取当前配置并携带 `SESSDATA/bili_jct/buvid3/DedeUserID/ac_time_value`，以及可选的 `buvid4/DedeUserID__ckMd5`，避免无 Cookie/buvid 指纹触发 412。
- 如果携带已配置 Cookie/buvid 后仍返回 412，错误提示改为“已携带凭据但仍被安全策略拒绝”；没有凭据或字段不完整时才提示扫码/补齐凭据。
- 搜索响应透出 B 站返回的 `num_pages`，前端按真实页数继续翻页，避免 `page_size` 被 B 站调整后少拉页面。
- 设置页新增“自动刷新诊断”手动测试入口，返回刷新阶段、错误类型、是否建议重试、字段长度和脱敏错误链，方便现场确认失败点。
- 设置页新增“强制刷新”按钮，只在手动诊断时跳过 `cookie/info.refresh=false` 判断，完整执行 `correspond -> cookie/refresh -> confirm/refresh` 并保存新凭据。
- 普通“测试刷新”现在会明确显示 `precheck_not_needed`，避免把“B 站说暂不需要刷新”误看成完整刷新成功。

## 原因
现场日志里 `Address not available (os error 99)` 发生在请求刷新 csrf 页面阶段，数据库中的认证字段完整，属于容器出网连接失败，不应直接判定为 Cookie 失效。后续本地实测发现当前 Cookie 返回 `refresh=false`，原诊断按钮只显示 `completed`，无法区分“没刷新”和“刷新链路真的成功”。

`error decoding response body` 的直接原因是搜索响应不是程序预期 JSON。复测确认 `/x/web-interface/search/type` 本身可用，但请求来源和浏览器指纹很敏感：裸请求/无痕/无 Cookie-buvid 指纹会返回 412；原程序默认 `Referer: https://www.bilibili.com` 时也可能拿到 412 的 HTML 风控页；浏览器搜索页 `Referer: https://search.bilibili.com/...` 且带登录态/指纹时正常返回 JSON。程序侧现在直接携带已配置的 Cookie/buvid，只有带了以后仍 412 才提示为风控。

## 验证
- `cargo check -p bili_sync`
- `cargo test -p bili_sync credential_refresh_transient_error_detects_network_failures`
- `rustfmt --check crates/bili_sync/src/bilibili/client.rs`
- `rustfmt --check crates/bili_sync/src/bilibili/credential.rs crates/bili_sync/src/bilibili/client.rs crates/bili_sync/src/api/handler.rs crates/bili_sync/src/api/request.rs crates/bili_sync/src/api/response.rs crates/bili_sync/src/task/http_server.rs`
- `npm run check:node20`
- `npm run build:node20`
- `cargo build -p bili_sync --bin bili-sync-rs`
- 直接调用 `POST /api/credential/test-refresh`：`force=false` 返回 `precheck_not_needed`，`force=true` 返回 `force_completed`。
- 直接调用 `GET /api/search?keyword=小王纸&search_type=bili_user&page=1&page_size=50`：第一页返回 50 条，`total=729`，`num_pages=15`。
- 循环调用 15 页搜索接口：累计 729 条、去重后 729 条。
- 浏览器手动验证：打开 `http://127.0.0.1:12345/add-source`，搜索“小王纸”，确认搜索结果面板显示 `共找到 729 个结果` 和 `共显示 729 个结果`。
- 浏览器手动验证：打开 `http://127.0.0.1:12345/settings`，进入 B 站凭证面板，确认“测试刷新”和“强制刷新”按钮可用；强制刷新后页面显示 `force_completed`，普通测试显示 `precheck_not_needed`。
