### PR TITLE
修复单P视频文件名模板不生效

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -692,6 +692,14 @@ fn process_path_with_filenamify(input: &str) -> String {
 #[cfg(test)]
 mod rename_tests {
     use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!("bili-sync-rename-{}-{}", prefix, uuid::Uuid::new_v4()));
+        dir
+    }
 
     #[test]
     fn test_process_path_with_filenamify_slash_handling() {
@@ -725,6 +733,42 @@ mod rename_tests {
         // 应该将所有斜杠转换为下划线
         assert_eq!(result, "普通视频标题_带斜杠");
         assert!(!result.contains('/'));
+    }
+
+    #[test]
+    fn test_generate_unique_folder_name_keeps_current_target_folder() {
+        let root = unique_temp_dir("current-target");
+        let base_name = "N_eko喵-3632302200458215/2026-05-22-BV1RTLe68Ebs-知道你们爱看点有劲的";
+        let current_path = root.join(base_name);
+        fs::create_dir_all(&current_path).expect("应能创建当前视频目录");
+
+        let unique_name =
+            generate_unique_folder_name(&root, base_name, "BV1RTLe68Ebs", "20260522100748", Some(&current_path));
+
+        assert_eq!(unique_name, base_name);
+        fs::remove_dir_all(root).expect("应能清理临时目录");
+    }
+
+    #[test]
+    fn test_generate_unique_folder_name_reuses_existing_identity_folder_when_db_path_is_stale() {
+        let root = unique_temp_dir("identity-target");
+        let base_name = "N_eko喵-3632302200458215/2026-05-22-BV1RTLe68Ebs-知道你们爱看点有劲的";
+        let expected_path = root.join(base_name);
+        let stale_path = root
+            .join("N_eko喵-3632302200458215/2026-05-22-BV1RTLe68Ebs-知道你们爱看点有劲的-20260522100748-BV1RTLe68Ebs");
+        fs::create_dir_all(&expected_path).expect("应能创建模板目标目录");
+        fs::create_dir_all(&stale_path).expect("应能创建旧数据库目录");
+        fs::write(
+            expected_path.join("2026-05-22-BV1RTLe68Ebs-知道你们爱看点有劲的.mp4"),
+            b"",
+        )
+        .expect("应能创建当前视频文件");
+
+        let unique_name =
+            generate_unique_folder_name(&root, base_name, "BV1RTLe68Ebs", "20260522100748", Some(&stale_path));
+
+        assert_eq!(unique_name, base_name);
+        fs::remove_dir_all(root).expect("应能清理临时目录");
     }
 }
 
@@ -8482,6 +8526,7 @@ async fn move_video_files_to_new_path(
                 &new_video_path,
                 &video.bvid,
                 &video.pubtime.format("%Y%m%d%H%M%S").to_string(),
+                Some(current_video_path),
             );
             new_video_dir.join(unique_video_path)
         } else {
@@ -11234,8 +11279,13 @@ async fn rename_existing_files(
                 let expected_new_path = if needs_deduplication {
                     let dedup_pubtime = video.pubtime.format("%Y%m%d%H%M%S").to_string();
                     // 使用智能去重生成唯一文件夹名
-                    let unique_folder_name =
-                        generate_unique_folder_name(base_parent_dir, &final_folder_name, &video.bvid, &dedup_pubtime);
+                    let unique_folder_name = generate_unique_folder_name(
+                        base_parent_dir,
+                        &final_folder_name,
+                        &video.bvid,
+                        &dedup_pubtime,
+                        Some(video_path),
+                    );
                     base_parent_dir.join(&unique_folder_name)
                 } else {
                     // 不使用去重，允许多个视频共享同一文件夹
@@ -15763,12 +15813,65 @@ pub async fn proxy_video_stream(
 
 /// 四步法安全重命名目录，避免父子目录冲突
 /// 生成唯一的文件夹名称，避免同名冲突
-fn generate_unique_folder_name(parent_dir: &std::path::Path, base_name: &str, bvid: &str, pubtime: &str) -> String {
+fn folder_name_contains_video_identity(folder_path: &std::path::Path, bvid: &str, pubtime: &str) -> bool {
+    let bvid = bvid.trim().to_lowercase();
+    let pubtime = pubtime.trim().to_lowercase();
+
+    folder_path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_lowercase())
+        .is_some_and(|folder_name| {
+            (!bvid.is_empty() && folder_name.contains(&bvid)) || (!pubtime.is_empty() && folder_name.contains(&pubtime))
+        })
+}
+
+fn folder_files_contain_video_identity(folder_path: &std::path::Path, bvid: &str, pubtime: &str) -> bool {
+    let bvid = bvid.trim().to_lowercase();
+    let pubtime = pubtime.trim().to_lowercase();
+    if bvid.is_empty() && pubtime.is_empty() {
+        return false;
+    }
+
+    std::fs::read_dir(folder_path).is_ok_and(|entries| {
+        entries.flatten().any(|entry| {
+            let file_name = entry.file_name().to_string_lossy().to_lowercase();
+            (!bvid.is_empty() && file_name.contains(&bvid)) || (!pubtime.is_empty() && file_name.contains(&pubtime))
+        })
+    })
+}
+
+fn folder_belongs_to_current_video(
+    folder_path: &std::path::Path,
+    bvid: &str,
+    pubtime: &str,
+    current_path: Option<&std::path::Path>,
+) -> bool {
+    if current_path.is_some_and(|path| {
+        same_path_for_reset(folder_path.to_string_lossy().as_ref(), path.to_string_lossy().as_ref())
+    }) {
+        return true;
+    }
+
+    folder_name_contains_video_identity(folder_path, bvid, pubtime)
+        || folder_files_contain_video_identity(folder_path, bvid, pubtime)
+}
+
+fn generate_unique_folder_name(
+    parent_dir: &std::path::Path,
+    base_name: &str,
+    bvid: &str,
+    pubtime: &str,
+    current_path: Option<&std::path::Path>,
+) -> String {
     let mut unique_name = base_name.to_string();
 
     // 检查基础名称是否已存在
     let base_path = parent_dir.join(&unique_name);
     if !base_path.exists() {
+        return unique_name;
+    }
+    if folder_belongs_to_current_video(&base_path, bvid, pubtime, current_path) {
+        debug!("文件夹 {:?} 已是当前视频的文件夹，无需追加去重后缀", base_path);
         return unique_name;
     }
 

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -11539,38 +11539,6 @@ async fn rename_existing_files(
                         format!("S{:02}E{:02}-{:02}", season_number, episode_number, episode_number)
                     }
                 }
-            } else if is_single_page && !is_collection {
-                if let Some(clean_name) = single_page_file_name_for_dedicated_folder(
-                    &final_video_path,
-                    &video.name,
-                    &page.name,
-                    &video.bvid,
-                    &video.pubtime.format("%Y%m%d%H%M%S").to_string(),
-                    config.video_name.as_ref(),
-                ) {
-                    debug!(
-                        "单P视频使用独立目录，重命名文件名改用标题: bvid={}, path={}, file_name={}",
-                        video.bvid,
-                        final_video_path.display(),
-                        clean_name
-                    );
-                    clean_name
-                } else {
-                    // 单P视频使用page_name模板
-                    match handlebars.render("page", &page_template_value) {
-                        Ok(rendered) => {
-                            debug!("单P视频模板渲染成功: '{}' -> '{}'", config.page_name, rendered);
-                            rendered
-                        }
-                        Err(e) => {
-                            warn!(
-                                "单P视频模板渲染失败: '{}', 错误: {}, 使用默认名称: '{}'",
-                                config.page_name, e, page.name
-                            );
-                            page.name.clone()
-                        }
-                    }
-                }
             } else if is_single_page {
                 // 单P视频使用page_name模板
                 match handlebars.render("page", &page_template_value) {
@@ -15828,44 +15796,6 @@ fn generate_unique_folder_name(parent_dir: &std::path::Path, base_name: &str, bv
 
 fn video_template_uses_video_title(video_template: &str) -> bool {
     video_template.contains("title") || (video_template.contains("name") && !video_template.contains("upper_name"))
-}
-
-fn folder_leaf_contains_video_identity(base_path: &std::path::Path, bvid: &str, pubtime: &str) -> bool {
-    let Some(folder_name) = base_path.file_name() else {
-        return false;
-    };
-    let folder_name = folder_name.to_string_lossy().to_lowercase();
-    let bvid = bvid.trim().to_lowercase();
-    let pubtime = pubtime.trim().to_lowercase();
-
-    (!bvid.is_empty() && folder_name.contains(&bvid)) || (!pubtime.is_empty() && folder_name.contains(&pubtime))
-}
-
-fn single_page_file_name_for_dedicated_folder(
-    final_video_path: &std::path::Path,
-    video_name: &str,
-    page_name: &str,
-    bvid: &str,
-    pubtime: &str,
-    video_template: &str,
-) -> Option<String> {
-    if !video_template_uses_video_title(video_template)
-        && !folder_leaf_contains_video_identity(final_video_path, bvid, pubtime)
-    {
-        return None;
-    }
-
-    let clean_video_name = crate::utils::filenamify::filenamify(video_name.trim());
-    if !clean_video_name.trim().is_empty() {
-        return Some(clean_video_name);
-    }
-
-    let clean_page_name = crate::utils::filenamify::filenamify(page_name.trim());
-    if clean_page_name.trim().is_empty() {
-        None
-    } else {
-        Some(clean_page_name)
-    }
 }
 
 /// 智能重组视频文件夹

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -6297,23 +6297,9 @@ async fn download_page(
                 format!("S{:02}E{:02}-{:02}", season_number, episode_number, episode_number)
             }
         }
-    } else if let Some(clean_name) = single_page_file_name_for_dedicated_folder(
-        base_path,
-        video_model,
-        &page_model,
-        crate::config::with_config(|bundle| video_template_uses_video_title(bundle.config.video_name.as_ref())),
-    ) {
-        debug!(
-            "单P视频使用独立目录，文件名改用标题: bvid={}, base_path={}, file_name={}",
-            video_model.bvid,
-            base_path.display(),
-            clean_name
-        );
-        clean_name
     } else {
         // 单P视频使用最新配置的page_name模板
-        crate::config::with_config(|bundle| bundle.render_page_template(&page_format_args(video_model, &page_model)))
-            .map_err(|e| anyhow::anyhow!("模板渲染失败: {}", e))?
+        render_single_page_base_name_from_config(video_model, &page_model)?
     };
 
     // 根据audio_only设置选择文件扩展名
@@ -12141,6 +12127,20 @@ fn resolve_sidecar_base_name(base_path: &std::path::Path, rendered_name: Option<
         .unwrap_or_else(|| fallback_title.to_string())
 }
 
+fn render_single_page_base_name(
+    bundle: &crate::config::ConfigBundle,
+    video_model: &video::Model,
+    page_model: &page::Model,
+) -> Result<String> {
+    bundle
+        .render_page_template(&page_format_args(video_model, page_model))
+        .map_err(|e| anyhow!("模板渲染失败: {}", e))
+}
+
+fn render_single_page_base_name_from_config(video_model: &video::Model, page_model: &page::Model) -> Result<String> {
+    crate::config::with_config(|bundle| render_single_page_base_name(bundle, video_model, page_model))
+}
+
 fn video_identity_suffix(video_model: &video::Model, pubtime: &str) -> String {
     let bvid = video_model.bvid.trim();
     if bvid.is_empty() {
@@ -12303,29 +12303,6 @@ fn preserve_existing_video_path_for_redownload(
     }
 }
 
-fn single_page_file_name_for_dedicated_folder(
-    base_path: &std::path::Path,
-    video_model: &video::Model,
-    page_model: &page::Model,
-    video_folder_is_dedicated: bool,
-) -> Option<String> {
-    if !video_folder_is_dedicated && !folder_leaf_contains_video_identity(base_path, video_model) {
-        return None;
-    }
-
-    let clean_video_name = crate::utils::filenamify::filenamify(video_model.name.trim());
-    if !clean_video_name.trim().is_empty() {
-        return Some(clean_video_name);
-    }
-
-    let clean_page_name = crate::utils::filenamify::filenamify(page_model.name.trim());
-    if clean_page_name.trim().is_empty() {
-        None
-    } else {
-        Some(clean_page_name)
-    }
-}
-
 /// 生成唯一的文件夹名称，避免同名冲突（增强版）
 pub fn generate_unique_folder_name(
     parent_dir: &std::path::Path,
@@ -12378,6 +12355,7 @@ mod tests {
     use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
     use sea_orm::{ActiveModelTrait, DatabaseConnection, Set, SqlxSqliteConnector};
     use serde_json::json;
+    use std::borrow::Cow;
     use std::fs;
     use std::path::PathBuf;
 
@@ -12817,61 +12795,43 @@ mod tests {
     }
 
     #[test]
-    fn test_single_page_file_name_for_identity_folder_uses_title() {
+    fn test_single_page_base_name_honors_page_template_when_video_template_has_folder() {
+        let config = crate::config::Config {
+            video_name: Cow::Borrowed("{{upper_name}}-{{upper_mid}}/{{pubtime}}-{{bvid}}-{{truncate title 20}}"),
+            page_name: Cow::Borrowed("{{pubtime}}-{{bvid}}-{{truncate title 20}}"),
+            ..Default::default()
+        };
+        let bundle = crate::config::ConfigBundle::from_config(config).expect("配置包应能创建");
+        let pubtime = chrono::NaiveDate::from_ymd_opt(2026, 5, 13)
+            .unwrap()
+            .and_hms_opt(12, 34, 56)
+            .unwrap();
         let video = video::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
-            bvid: "BV1TestSplit001".to_string(),
-            pubtime: chrono::NaiveDate::from_ymd_opt(2026, 4, 28)
-                .unwrap()
-                .and_hms_opt(17, 8, 30)
-                .unwrap(),
+            name: "abcdefghijklmnopqrstuv".to_string(),
+            upper_name: "creator".to_string(),
+            upper_id: 89428420,
+            bvid: "BV1Um5k63ERL".to_string(),
+            pubtime,
+            favtime: pubtime,
+            single_page: Some(true),
             ..Default::default()
         };
         let page = page::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
+            name: video.name.clone(),
+            pid: 1,
             ..Default::default()
         };
-        let base_path = PathBuf::from("测试UP").join("ψ(｀∇´)ψ-20260428170830-BV1TestSplit001");
 
-        let file_name = single_page_file_name_for_dedicated_folder(&base_path, &video, &page, false);
+        let rendered_video_folder = bundle
+            .render_video_template(&video_format_args(&video))
+            .expect("视频目录模板应能渲染");
+        let rendered_page_name = render_single_page_base_name(&bundle, &video, &page).expect("单P文件名模板应能渲染");
 
-        assert_eq!(file_name.as_deref(), Some("ψ(｀∇´)ψ"));
-    }
-
-    #[test]
-    fn test_single_page_file_name_for_plain_dedicated_folder_uses_title() {
-        let video = video::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
-            bvid: "BV1TestSplit002".to_string(),
-            ..Default::default()
-        };
-        let page = page::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
-            ..Default::default()
-        };
-        let base_path = PathBuf::from("测试UP").join("ψ(｀∇´)ψ");
-
-        let file_name = single_page_file_name_for_dedicated_folder(&base_path, &video, &page, true);
-
-        assert_eq!(file_name.as_deref(), Some("ψ(｀∇´)ψ"));
-    }
-
-    #[test]
-    fn test_single_page_file_name_for_shared_folder_keeps_template() {
-        let video = video::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
-            bvid: "BV1TestSplit003".to_string(),
-            ..Default::default()
-        };
-        let page = page::Model {
-            name: "ψ(｀∇´)ψ".to_string(),
-            ..Default::default()
-        };
-        let base_path = PathBuf::from("测试UP").join("ψ(｀∇´)ψ");
-
-        let file_name = single_page_file_name_for_dedicated_folder(&base_path, &video, &page, false);
-
-        assert_eq!(file_name, None);
+        assert_eq!(
+            rendered_video_folder,
+            "creator-89428420/20260513123456-BV1Um5k63ERL-abcdefghijklmnopqrst"
+        );
+        assert_eq!(rendered_page_name, "20260513123456-BV1Um5k63ERL-abcdefghijklmnopqrst");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Fixes #174。

v3.0.8 里为了解决同标题视频目录冲突，加入了“单 P 独立目录内文件名改用标题”的逻辑。这个逻辑会在 `video_name` 带标题或目录末级带 BV/发布时间时绕过 `page_name`，导致用户配置的单 P 视频文件名模板不生效，最终文件只剩 `标题.mp4`。

## 修改

- 下载单 P 视频时，文件基名重新固定走 `page_name` 模板。
- 重设路径/重命名已有文件时，同样不再用标题覆盖 `page_name`。
- 保留目录冲突修复逻辑：同标题目录去重、发布时间+BVID 后缀、重下保留已确认目录不变。
- 添加回归测试，覆盖 `video_name` 含目录且 `page_name` 含发布时间/BV/截断标题的场景。

## 验证

```text
cargo test -p bili_sync test_single_page_base_name_honors_page_template_when_video_template_has_folder
cargo test -p bili_sync test_generate_unique_folder_name
cargo test -p bili_sync test_preserve_existing_video_path_for_redownload
cargo check -p bili_sync
```