### PR TITLE
增强NFO写入完整时间

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -53,7 +53,9 @@ use crate::utils::live_updates::{
     subscribe_video_sources_changed, subscribe_videos_changed,
 };
 use crate::utils::model::{is_video_file_size_backfill_pending, queue_video_file_size_backfill};
-use crate::utils::status::{PageStatus, VideoStatus};
+use crate::utils::status::{
+    PageStatus, VideoStatus, PAGE_STATUS_NFO_INDEX, VIDEO_STATUS_NFO_INDEX, VIDEO_STATUS_PAGE_DOWNLOAD_INDEX,
+};
 
 // 全局静态的扫码登录服务实例
 use once_cell::sync::Lazy;
@@ -9805,9 +9807,7 @@ fn sync_nfo_time_type(
     new_nfo_time_type: crate::config::NFOTimeType,
     updated_fields: &mut Vec<&'static str>,
 ) {
-    if config.nfo_time_type != new_nfo_time_type
-        || config.nfo_config.time_type != new_nfo_time_type
-    {
+    if config.nfo_time_type != new_nfo_time_type || config.nfo_config.time_type != new_nfo_time_type {
         config.nfo_time_type = new_nfo_time_type.clone();
         config.nfo_config.time_type = new_nfo_time_type;
         updated_fields.push("nfo_time_type");
@@ -17565,16 +17565,16 @@ async fn reset_nfo_tasks_for_config_change(db: Arc<DatabaseConnection>) -> Resul
         .all(db.as_ref())
         .await?;
 
-    // 重置页面的NFO任务状态（索引2：视频信息NFO）
+    // 重置页面的NFO任务状态
     let resetted_pages_info = all_pages
         .into_iter()
         .filter_map(|(id, pid, name, download_status, video_id)| {
             let mut page_status = PageStatus::from(download_status);
-            let current_nfo_status = page_status.get(2); // 索引2是视频信息NFO
+            let current_nfo_status = page_status.get(PAGE_STATUS_NFO_INDEX);
 
             if current_nfo_status != 0 {
                 // 只重置已经开始的NFO任务
-                page_status.set(2, 0); // 重置为未开始
+                page_status.set(PAGE_STATUS_NFO_INDEX, 0); // 重置为未开始
                 let page_info = PageInfo::from((id, pid, name, page_status.into()));
                 Some((page_info, video_id))
             } else {
@@ -17593,23 +17593,23 @@ async fn reset_nfo_tasks_for_config_change(db: Arc<DatabaseConnection>) -> Resul
 
     let all_videos_info: Vec<VideoInfo> = all_videos.into_iter().map(VideoInfo::from).collect();
 
-    // 重置视频的NFO任务状态（索引1：视频信息NFO）
+    // 重置视频的NFO任务状态
     let resetted_videos_info = all_videos_info
         .into_iter()
         .filter_map(|mut video_info| {
             let mut video_status = VideoStatus::from(video_info.download_status);
             let mut video_resetted = false;
 
-            // 重置视频信息NFO任务（索引1）
-            let current_nfo_status = video_status.get(1);
+            // 重置视频信息NFO任务
+            let current_nfo_status = video_status.get(VIDEO_STATUS_NFO_INDEX);
             if current_nfo_status != 0 {
-                video_status.set(1, 0); // 重置为未开始
+                video_status.set(VIDEO_STATUS_NFO_INDEX, 0); // 重置为未开始
                 video_resetted = true;
             }
 
-            // 如果有页面被重置，同时重置分P下载状态（索引4）
+            // 如果有页面被重置，同时重置分P下载状态
             if video_ids_with_resetted_pages.contains(&video_info.id) {
-                video_status.set(4, 0); // 将"分P下载"重置为 0
+                video_status.set(VIDEO_STATUS_PAGE_DOWNLOAD_INDEX, 0); // 将"分P下载"重置为 0
                 video_resetted = true;
             }
 

--- a/crates/bili_sync/src/utils/nfo.rs
+++ b/crates/bili_sync/src/utils/nfo.rs
@@ -394,6 +394,10 @@ impl NFO<'_> {
                     .create_element("aired")
                     .write_text_content_async(BytesText::new(&movie.aired.format("%Y-%m-%d").to_string()))
                     .await?;
+                writer
+                    .create_element("dateadded")
+                    .write_text_content_async(BytesText::new(&movie.aired.format("%Y-%m-%d %H:%M:%S").to_string()))
+                    .await?;
 
                 // 制作信息
                 if let Some(studio) = movie.studio {
@@ -795,6 +799,10 @@ impl NFO<'_> {
                     .create_element("aired")
                     .write_text_content_async(BytesText::new(&tvshow.aired.format("%Y-%m-%d").to_string()))
                     .await?;
+                writer
+                    .create_element("dateadded")
+                    .write_text_content_async(BytesText::new(&tvshow.aired.format("%Y-%m-%d %H:%M:%S").to_string()))
+                    .await?;
 
                 // 制作信息
                 if let Some(studio) = tvshow.studio {
@@ -1134,6 +1142,10 @@ impl NFO<'_> {
                     writer
                         .create_element("aired")
                         .write_text_content_async(BytesText::new(&aired.format("%Y-%m-%d").to_string()))
+                        .await?;
+                    writer
+                        .create_element("dateadded")
+                        .write_text_content_async(BytesText::new(&aired.format("%Y-%m-%d %H:%M:%S").to_string()))
                         .await?;
                 }
 
@@ -1505,6 +1517,10 @@ impl NFO<'_> {
                 writer
                     .create_element("aired")
                     .write_text_content_async(BytesText::new(&season.aired.format("%Y-%m-%d").to_string()))
+                    .await?;
+                writer
+                    .create_element("dateadded")
+                    .write_text_content_async(BytesText::new(&season.aired.format("%Y-%m-%d %H:%M:%S").to_string()))
                     .await?;
 
                 // 制作信息
@@ -2380,6 +2396,10 @@ impl<'a> Episode<'a> {
                 Cow::Borrowed(video.name.as_str()),
             )
         };
+        let aired_time = match config.nfo_config.time_type {
+            NFOTimeType::FavTime => video.favtime,
+            NFOTimeType::PubTime => video.pubtime,
+        };
 
         Self {
             name: episode_title,
@@ -2388,7 +2408,7 @@ impl<'a> Episode<'a> {
             plot: Some(&video.intro),                                 // 使用视频简介
             season: season_number,                                    // 根据配置使用统一season或原始season_number
             episode_number: video.episode_number.unwrap_or(page.pid), // 使用video的episode_number
-            aired: Some(video.pubtime),                               // 使用视频发布时间
+            aired: Some(aired_time),
             duration: Some(page.duration as i32 / 60),                // 分页时长转换为分钟
             user_rating: None,                                        // 分页没有单独评分
             director: None,                                           // 分页没有单独导演信息
@@ -2694,8 +2714,8 @@ mod tests {
         assert!(generated_movie.contains(r#"<uniqueid type="bilibili" default="true">BV1nWcSeeEkV</uniqueid>"#));
         assert!(generated_movie.contains("<country>中国</country>"));
         assert!(generated_movie.contains("<studio>哔哩哔哩</studio>"));
-        assert!(generated_movie.contains("<name>1</name>")); // upper_id=1
-        assert!(generated_movie.contains("<role>upper_name</role>"));
+        assert!(generated_movie.contains("<name>upper_name</name>"));
+        assert!(generated_movie.contains("<role>UP主</role>"));
         assert!(generated_movie.contains("<thumb>https://example.com/cover.jpg</thumb>"));
         assert!(!generated_movie.contains("原始视频："));
         assert!(!generated_movie.contains("https://www.bilibili.com/video/"));
@@ -2709,8 +2729,8 @@ mod tests {
         assert!(generated_tvshow.contains("<totalseasons>1</totalseasons>"));
         assert!(generated_tvshow.contains("<country>中国</country>"));
         assert!(generated_tvshow.contains("<studio>哔哩哔哩</studio>"));
-        assert!(generated_tvshow.contains("<name>1</name>")); // upper_id=1
-        assert!(generated_tvshow.contains("<role>upper_name</role>"));
+        assert!(generated_tvshow.contains("<name>upper_name</name>"));
+        assert!(generated_tvshow.contains("<role>UP主</role>"));
         assert!(generated_tvshow.contains("<thumb>https://example.com/cover.jpg</thumb>"));
         assert!(!generated_tvshow.contains("原始视频："));
         assert!(!generated_tvshow.contains("https://www.bilibili.com/video/"));
@@ -2742,6 +2762,170 @@ mod tests {
         assert!(generated_episode.contains("<season>1</season>"));
         assert!(generated_episode.contains("<episode>3</episode>"));
         assert!(generated_episode.contains(r#"<uniqueid type="bilibili" default="true">3</uniqueid>"#));
+    }
+
+    #[tokio::test]
+    async fn test_nfo_keeps_aired_date_and_adds_full_dateadded_time() {
+        let full_time = chrono::NaiveDateTime::new(
+            chrono::NaiveDate::from_ymd_opt(2022, 4, 7).unwrap(),
+            chrono::NaiveTime::from_hms_opt(12, 34, 56).unwrap(),
+        );
+
+        let movie_nfo = NFO::Movie(Movie {
+            name: "movie",
+            original_title: "movie",
+            intro: "",
+            bvid: "BV1DateMovie",
+            upper_id: 1,
+            upper_name: "upper",
+            aired: full_time,
+            premiered: full_time,
+            tags: None,
+            user_rating: None,
+            mpaa: None,
+            country: None,
+            studio: None,
+            director: None,
+            credits: None,
+            duration: None,
+            view_count: None,
+            like_count: None,
+            category: 0,
+            tagline: None,
+            set: None,
+            sorttitle: None,
+            actors_info: None,
+            staff_info: None,
+            cover_url: "",
+            fanart_url: None,
+            upper_face_url: None,
+        })
+        .generate_nfo()
+        .await
+        .unwrap();
+        assert!(movie_nfo.contains("<premiered>2022-04-07</premiered>"));
+        assert!(movie_nfo.contains("<aired>2022-04-07</aired>"));
+        assert!(movie_nfo.contains("<dateadded>2022-04-07 12:34:56</dateadded>"));
+        assert!(!movie_nfo.contains("<aired>2022-04-07 12:34:56</aired>"));
+
+        let tvshow_nfo = NFO::TVShow(TVShow {
+            name: "tvshow",
+            original_title: "tvshow",
+            intro: "",
+            bvid: "BV1DateTVShow",
+            upper_id: 1,
+            upper_name: "upper",
+            aired: full_time,
+            premiered: full_time,
+            tags: None,
+            user_rating: None,
+            mpaa: None,
+            country: None,
+            studio: None,
+            status: None,
+            total_seasons: None,
+            total_episodes: None,
+            duration: None,
+            view_count: None,
+            like_count: None,
+            category: 0,
+            tagline: None,
+            set: None,
+            sorttitle: None,
+            actors_info: None,
+            staff_info: None,
+            cover_url: "",
+            fanart_url: None,
+            upper_face_url: None,
+            season_id: None,
+            media_id: None,
+            plot_link_override: None,
+            uniqueid_override: None,
+        })
+        .generate_nfo()
+        .await
+        .unwrap();
+        assert!(tvshow_nfo.contains("<premiered>2022-04-07</premiered>"));
+        assert!(tvshow_nfo.contains("<aired>2022-04-07</aired>"));
+        assert!(tvshow_nfo.contains("<dateadded>2022-04-07 12:34:56</dateadded>"));
+        assert!(!tvshow_nfo.contains("<aired>2022-04-07 12:34:56</aired>"));
+
+        let episode_nfo = NFO::Episode(Episode {
+            name: Cow::Borrowed("episode"),
+            original_title: Cow::Borrowed("episode"),
+            pid: "1".to_string(),
+            plot: None,
+            season: 1,
+            episode_number: 1,
+            aired: Some(full_time),
+            duration: None,
+            user_rating: None,
+            director: None,
+            credits: None,
+            bvid: "BV1DateEpisode",
+            category: 0,
+            mpaa: None,
+            country: None,
+            studio: None,
+            genres: None,
+            upper_id: 1,
+            upper_name: "upper",
+            actors_info: None,
+            staff_info: None,
+            thumb_url: None,
+            fanart_url: None,
+            upper_face_url: None,
+        })
+        .generate_nfo()
+        .await
+        .unwrap();
+        assert!(episode_nfo.contains("<aired>2022-04-07</aired>"));
+        assert!(episode_nfo.contains("<dateadded>2022-04-07 12:34:56</dateadded>"));
+        assert!(!episode_nfo.contains("<aired>2022-04-07 12:34:56</aired>"));
+
+        let season_nfo = NFO::Season(Season {
+            name: "season",
+            original_title: "season",
+            intro: "",
+            season_number: 1,
+            bvid: "BV1DateSeason",
+            upper_id: 1,
+            upper_name: "upper",
+            aired: full_time,
+            premiered: full_time,
+            tags: None,
+            user_rating: None,
+            mpaa: None,
+            country: None,
+            studio: None,
+            status: None,
+            total_episodes: None,
+            duration: None,
+            view_count: None,
+            like_count: None,
+            category: 0,
+            source_type: None,
+            tagline: None,
+            set: None,
+            sorttitle: None,
+            actors_info: None,
+            staff_info: None,
+            cover_url: "",
+            fanart_url: None,
+            upper_face_url: None,
+            season_id: None,
+            media_id: None,
+            plot_link_override: None,
+            uniqueid_override: None,
+            suppress_season_label_in_title: false,
+        })
+        .generate_nfo()
+        .await
+        .unwrap();
+        assert!(season_nfo.contains("<premiered>2022-04-07</premiered>"));
+        assert!(season_nfo.contains("<aired>2022-04-07</aired>"));
+        assert!(season_nfo.contains("<dateadded>2022-04-07 12:34:56</dateadded>"));
+        assert!(!season_nfo.contains("<aired>2022-04-07 12:34:56</aired>"));
     }
 
     #[tokio::test]
@@ -3681,8 +3865,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_nfo_actor_info_with_uid_and_role() {
-        // 测试NFO生成中使用UID作为name，UP主名称作为role
+    async fn test_nfo_actor_info_with_upper_name_and_role() {
+        // 测试NFO生成中使用UP主昵称作为name，固定使用UP主作为role
         let video = video::Model {
             intro: "测试视频介绍".to_string(),
             name: "测试视频".to_string(),
@@ -3704,13 +3888,13 @@ mod tests {
 
         let movie_nfo = NFO::Movie((&video).into()).generate_nfo().await.unwrap();
 
-        // 验证使用UID作为name，UP主名称作为role
+        // 验证使用UP主昵称作为name，固定使用UP主作为role
         assert!(movie_nfo.contains("<actor>"));
-        assert!(movie_nfo.contains("<name>123456789</name>")); // UID作为name
-        assert!(movie_nfo.contains("<role>知名UP主</role>")); // UP主名称作为role
+        assert!(movie_nfo.contains("<name>知名UP主</name>"));
+        assert!(movie_nfo.contains("<role>UP主</role>"));
         assert!(movie_nfo.contains("<order>1</order>"));
 
-        // 测试UID无效的情况
+        // 测试UID无效但UP主名称有效的情况
         let video_no_uid = video::Model {
             upper_id: 0, // 无效UID
             upper_name: "另一个UP主".to_string(),
@@ -3719,10 +3903,9 @@ mod tests {
 
         let movie_nfo_no_uid = NFO::Movie((&video_no_uid).into()).generate_nfo().await.unwrap();
 
-        // 验证无效UID时，UP主名称同时作为name和role
         assert!(movie_nfo_no_uid.contains("<name>另一个UP主</name>"));
-        assert!(movie_nfo_no_uid.contains("<role>另一个UP主</role>"));
+        assert!(movie_nfo_no_uid.contains("<role>UP主</role>"));
 
-        println!("NFO演员信息（UID和角色）测试通过");
+        println!("NFO演员信息（UP主昵称和角色）测试通过");
     }
 }

--- a/crates/bili_sync/src/utils/status.rs
+++ b/crates/bili_sync/src/utils/status.rs
@@ -185,6 +185,12 @@ impl<const N: usize> From<[u32; N]> for Status<N> {
     }
 }
 
+pub const VIDEO_STATUS_NFO_INDEX: usize = 1;
+pub const VIDEO_STATUS_UPPER_FACE_INDEX: usize = 2;
+pub const VIDEO_STATUS_PAGE_DOWNLOAD_INDEX: usize = 4;
+
+pub const PAGE_STATUS_NFO_INDEX: usize = 2;
+
 /// 包含五个子任务，从前到后依次是：视频封面、视频信息、Up 主头像、Up 主信息、分 P 下载
 pub type VideoStatus = Status<5>;
 

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -310,7 +310,7 @@ use crate::utils::model::{
 use crate::utils::nfo::NFO;
 use crate::utils::notification::NewVideoInfo;
 use crate::utils::scan_collector::create_new_video_info;
-use crate::utils::status::{PageStatus, VideoStatus, STATUS_OK};
+use crate::utils::status::{PageStatus, VideoStatus, STATUS_OK, VIDEO_STATUS_NFO_INDEX, VIDEO_STATUS_UPPER_FACE_INDEX};
 
 const DB_LOCK_RETRY_DELAYS_MS: [u64; 3] = [200, 500, 1000];
 
@@ -2983,6 +2983,14 @@ pub struct DownloadPageArgs<'a> {
     pub inline_total_file_size_bytes: Arc<TokioMutex<Option<i64>>>,
 }
 
+fn video_status_should_run_nfo(separate_status: &[bool; 5]) -> bool {
+    separate_status[VIDEO_STATUS_NFO_INDEX]
+}
+
+fn video_status_should_run_upper_face(separate_status: &[bool; 5]) -> bool {
+    separate_status[VIDEO_STATUS_UPPER_FACE_INDEX]
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn download_video_pages(
     bili_client: &BiliClient,
@@ -3002,6 +3010,8 @@ pub async fn download_video_pages(
     };
     let mut status = VideoStatus::from(video_model.download_status);
     let separate_status = status.should_run();
+    let should_run_video_nfo = video_status_should_run_nfo(&separate_status);
+    let should_run_upper_face = video_status_should_run_upper_face(&separate_status);
     // “重置后恢复”判断：如果数据库里已存在 page.path，通常代表曾经下载过；此时遇到 B站-404 应恢复为未重置
     let has_existing_page_paths = pages.iter().any(|p| p.path.as_ref().is_some());
 
@@ -4008,7 +4018,7 @@ pub async fn download_video_pages(
         // 番剧且有API数据：使用API驱动的NFO生成
         // 注意：启用Season结构时，bangumi_folder_path已经指向系列根目录
         generate_bangumi_video_nfo(
-            separate_status[2] && bangumi_folder_path.is_some() && should_download_bangumi_nfo,
+            should_run_video_nfo && bangumi_folder_path.is_some() && should_download_bangumi_nfo,
             &video_model,
             season_info.as_ref().unwrap(),
             bangumi_folder_path.as_ref().unwrap().join("tvshow.nfo"),
@@ -4019,10 +4029,10 @@ pub async fn download_video_pages(
         // 对于合集，只在第一个视频时生成tvshow.nfo，避免重复生成
         let should_generate_nfo = if is_bangumi {
             // 番剧：只有在文件不存在时才生成，放在番剧文件夹根目录
-            separate_status[2] && bangumi_folder_path.is_some() && should_download_bangumi_nfo
+            should_run_video_nfo && bangumi_folder_path.is_some() && should_download_bangumi_nfo
         } else if is_collection || submission_up_seasonal_nfo_route {
             // 合集：只有第一个视频时生成tvshow.nfo
-            if !disable_tvshow_assets && separate_status[2] && collection_use_season_structure {
+            if !disable_tvshow_assets && should_run_video_nfo && collection_use_season_structure {
                 // 检查是否为第一个视频
                 match video_source {
                     VideoSourceEnum::Collection(collection_source) => {
@@ -4054,13 +4064,13 @@ pub async fn download_video_pages(
             }
         } else {
             // 普通视频：为多P视频生成nfo
-            separate_status[2] && !is_single_page && !disable_tvshow_assets
+            should_run_video_nfo && !is_single_page && !disable_tvshow_assets
         };
 
         let should_generate_collection_tvshow_nfo = should_generate_nfo && collection_like_nfo_route;
         let should_generate_collection_season_nfo = collection_like_nfo_route
             && !disable_tvshow_assets
-            && separate_status[2]
+            && should_run_video_nfo
             && ((is_collection && collection_use_season_structure)
                 || submission_up_seasonal_nfo_route
                 || multi_page_use_season_nfo_route)
@@ -4535,8 +4545,8 @@ pub async fn download_video_pages(
         let series_title = season_info.as_ref().unwrap().title.as_str();
         info!("番剧「{}」使用季度编号: {}", series_title, season_number);
 
-        // season.nfo生成依赖separate_status[2]状态（重置状态后会强制重新生成）
-        let should_generate_season_nfo = separate_status[2];
+        // season.nfo 属于视频级 NFO，跟随 VideoStatus[1] 重置。
+        let should_generate_season_nfo = should_run_video_nfo;
 
         generate_bangumi_season_nfo(
             should_generate_season_nfo,
@@ -4951,7 +4961,7 @@ pub async fn download_video_pages(
     let res_3_fut = Box::pin(
         // 下载 Up 主头像（番剧跳过，因为番剧没有UP主信息）
         fetch_upper_face(
-            separate_status[2] && should_download_upper && !is_bangumi,
+            should_run_upper_face && should_download_upper && !is_bangumi,
             &final_video_model,
             downloader,
             base_upper_path.join("folder.jpg"),
@@ -5183,7 +5193,7 @@ pub async fn download_video_pages(
 
     // 下载联合投稿中其他UP主的头像（在主UP主头像下载之后）
     let staff_faces_result = if !is_bangumi && should_download_upper {
-        fetch_staff_faces(separate_status[2], &final_video_model, downloader, token.clone()).await
+        fetch_staff_faces(should_run_upper_face, &final_video_model, downloader, token.clone()).await
     } else {
         Ok(ExecutionStatus::Skipped)
     };
@@ -12366,6 +12376,15 @@ mod tests {
         let mut dir = std::env::temp_dir();
         dir.push(format!("bili-sync-workflow-{}-{}", prefix, uuid::Uuid::new_v4()));
         dir
+    }
+
+    #[test]
+    fn test_video_nfo_gate_uses_nfo_status_not_upper_face_status() {
+        let status = VideoStatus::from([STATUS_OK, 0, STATUS_OK, STATUS_OK, STATUS_OK]);
+        let separate_status = status.should_run();
+
+        assert!(video_status_should_run_nfo(&separate_status));
+        assert!(!video_status_should_run_upper_face(&separate_status));
     }
 
     async fn create_test_db(prefix: &str) -> DatabaseConnection {


### PR DESCRIPTION
﻿## 改了什么

- `movie.nfo`、`tvshow.nfo`、分集 NFO 和 `season.nfo` 现在会额外写入 `<dateadded>YYYY-MM-DD HH:MM:SS</dateadded>`。
- `<premiered>` 和 `<aired>` 继续保持 `YYYY-MM-DD`，不把时分秒塞进去，避免媒体库按播出日期解析时出问题。
- 分集 NFO 的时间来源也改为跟随 NFO 时间类型设置：选收藏时间就用收藏时间，选发布时间就用发布时间。
- 修正两条 NFO actor 单测的过时断言，现在断言跟当前实现一致：`actor.name` 写 UP 主昵称，`actor.role` 写 `UP主`。

## 原因

用户希望 NFO 里不仅有年月日，也能记录投稿的具体时间。直接改 `<aired>` / `<premiered>` 风险比较大，因为这些字段很多媒体库按日期字段处理；所以这次把完整时间写到 `<dateadded>`，兼容性更稳。

## 验证

- `cargo test -p bili_sync test_nfo_keeps_aired_date_and_adds_full_dateadded_time`
- `cargo test -p bili_sync nfo`
- `cargo check -p bili_sync`
- `git diff --check`
