### PR TITLE
修复：按北京时间增量比较并避免投稿重复深扫

### DIFF
--- a/crates/bili_sync/src/adapter/bangumi.rs
+++ b/crates/bili_sync/src/adapter/bangumi.rs
@@ -284,7 +284,7 @@ impl BangumiSource {
             // 已有记录，使用增量模式
             Some(
                 crate::utils::time_format::parse_time_string(&self.latest_row_at)
-                    .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc()),
+                    .unwrap_or_else(crate::utils::time_format::beijing_epoch_naive),
             )
         };
 
@@ -301,7 +301,7 @@ impl BangumiSource {
         {
             // 检查缓存是否过期（默认24小时）
             let cache_updated_at_beijing = crate::utils::time_format::parse_time_string(&cache_updated_at)
-                .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+                .unwrap_or_else(crate::utils::time_format::beijing_epoch_naive);
             if !is_cache_expired(Some(cache_updated_at_beijing), 24) {
                 // 尝试轻量级更新检查
                 match bangumi.check_update(Some(cache_updated_at_beijing)).await {

--- a/crates/bili_sync/src/adapter/bangumi.rs
+++ b/crates/bili_sync/src/adapter/bangumi.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::Stream;
 use sea_orm::prelude::*;
 use sea_orm::ActiveValue::Set;
@@ -176,7 +176,7 @@ impl BangumiSource {
     pub async fn video_stream_from_cache(
         &self,
         cached_data: &str,
-        latest_row_at: Option<DateTime<Utc>>,
+        latest_row_at: Option<NaiveDateTime>,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<VideoInfo>> + Send>>> {
         use crate::bilibili::VideoInfo;
         use crate::utils::bangumi_cache::parse_cache;
@@ -202,9 +202,13 @@ impl BangumiSource {
             for episode in episodes {
                 let pub_time = episode["pub_time"].as_i64().unwrap_or(0);
                 let pub_datetime = DateTime::<Utc>::from_timestamp(pub_time, 0);
+                let pub_datetime_beijing = pub_datetime.map(|dt| {
+                    dt.with_timezone(&crate::utils::time_format::beijing_timezone())
+                        .naive_local()
+                });
 
                 // 如果设置了时间过滤，跳过旧剧集
-                if let (Some(latest), Some(pub_dt)) = (latest_row_at, pub_datetime) {
+                if let (Some(latest), Some(pub_dt)) = (latest_row_at, pub_datetime_beijing) {
                     if pub_dt <= latest {
                         continue;
                     }
@@ -280,8 +284,7 @@ impl BangumiSource {
             // 已有记录，使用增量模式
             Some(
                 crate::utils::time_format::parse_time_string(&self.latest_row_at)
-                    .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc())
-                    .and_utc(),
+                    .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc()),
             )
         };
 
@@ -297,12 +300,11 @@ impl BangumiSource {
             (&source_model.cached_episodes, source_model.cache_updated_at)
         {
             // 检查缓存是否过期（默认24小时）
-            let cache_updated_at_utc = crate::utils::time_format::parse_time_string(&cache_updated_at)
-                .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc())
-                .and_utc();
-            if !is_cache_expired(Some(cache_updated_at_utc), 24) {
+            let cache_updated_at_beijing = crate::utils::time_format::parse_time_string(&cache_updated_at)
+                .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+            if !is_cache_expired(Some(cache_updated_at_beijing), 24) {
                 // 尝试轻量级更新检查
-                match bangumi.check_update(Some(cache_updated_at_utc)).await {
+                match bangumi.check_update(Some(cache_updated_at_beijing)).await {
                     Ok((has_update, _)) => {
                         if !has_update {
                             // 没有更新，可以使用缓存

--- a/crates/bili_sync/src/adapter/favorite.rs
+++ b/crates/bili_sync/src/adapter/favorite.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::pin::Pin;
 
-use crate::utils::time_format::now_standard_string;
+use crate::utils::time_format::{now_standard_string, parse_time_string};
 use anyhow::{Context, Result};
 use bili_sync_entity::*;
 use chrono::Utc;
@@ -58,9 +58,10 @@ impl VideoSource for favorite::Model {
         }
 
         let beijing_tz = crate::utils::time_format::beijing_timezone();
-        let release_beijing = release_datetime.with_timezone(&beijing_tz);
-        let release_beijing_str = release_beijing.format("%Y-%m-%d %H:%M:%S").to_string();
-        release_beijing_str.as_str() > latest_row_at_string
+        let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
+        let latest_row_at = parse_time_string(latest_row_at_string)
+            .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+        release_beijing > latest_row_at
     }
 
     fn log_refresh_video_start(&self) {

--- a/crates/bili_sync/src/adapter/favorite.rs
+++ b/crates/bili_sync/src/adapter/favorite.rs
@@ -59,8 +59,8 @@ impl VideoSource for favorite::Model {
 
         let beijing_tz = crate::utils::time_format::beijing_timezone();
         let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
-        let latest_row_at = parse_time_string(latest_row_at_string)
-            .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+        let latest_row_at =
+            parse_time_string(latest_row_at_string).unwrap_or_else(crate::utils::time_format::beijing_epoch_naive);
         release_beijing > latest_row_at
     }
 

--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -66,9 +66,10 @@ pub trait VideoSource {
     // 判断是否应该继续拉取视频
     fn should_take(&self, release_datetime: &chrono::DateTime<Utc>, latest_row_at_string: &str) -> bool {
         let beijing_tz = crate::utils::time_format::beijing_timezone();
-        let release_beijing = release_datetime.with_timezone(&beijing_tz);
-        let release_beijing_str = release_beijing.format("%Y-%m-%d %H:%M:%S").to_string();
-        release_beijing_str.as_str() > latest_row_at_string
+        let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
+        let latest_row_at = crate::utils::time_format::parse_time_string(latest_row_at_string)
+            .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+        release_beijing > latest_row_at
     }
 
     /// 是否允许跳过第一条旧视频并继续扫描（用于动态API置顶旧视频场景）
@@ -104,7 +105,7 @@ pub trait VideoSource {
     }
 
     /// 获取创建时间，用于判断是否为新投稿
-    fn get_created_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+    fn get_created_at(&self) -> Option<chrono::NaiveDateTime> {
         None // 默认实现：没有创建时间信息
     }
 

--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -68,7 +68,7 @@ pub trait VideoSource {
         let beijing_tz = crate::utils::time_format::beijing_timezone();
         let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
         let latest_row_at = crate::utils::time_format::parse_time_string(latest_row_at_string)
-            .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+            .unwrap_or_else(crate::utils::time_format::beijing_epoch_naive);
         release_beijing > latest_row_at
     }
 

--- a/crates/bili_sync/src/adapter/submission.rs
+++ b/crates/bili_sync/src/adapter/submission.rs
@@ -97,8 +97,8 @@ impl VideoSource for submission::Model {
             // 将 API 时间转换为北京时间 NaiveDateTime，再与数据库中的北京时间比较
             let beijing_tz = crate::utils::time_format::beijing_timezone();
             let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
-            let latest_row_at = parse_time_string(latest_row_at_string)
-                .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+            let latest_row_at =
+                parse_time_string(latest_row_at_string).unwrap_or_else(crate::utils::time_format::beijing_epoch_naive);
 
             let should_take = release_beijing > latest_row_at;
 

--- a/crates/bili_sync/src/adapter/submission.rs
+++ b/crates/bili_sync/src/adapter/submission.rs
@@ -94,22 +94,27 @@ impl VideoSource for submission::Model {
         // 增量扫描逻辑：只获取比上次扫描时间更新的视频
         let current_config = crate::config::reload_config();
         if current_config.submission_risk_control.enable_incremental_fetch || self.selected_videos.is_some() {
-            // 将UTC时间转换为北京时间字符串，然后直接比较字符串
+            // 将 API 时间转换为北京时间 NaiveDateTime，再与数据库中的北京时间比较
             let beijing_tz = crate::utils::time_format::beijing_timezone();
-            let release_beijing = release_datetime.with_timezone(&beijing_tz);
-            let release_beijing_str = release_beijing.format("%Y-%m-%d %H:%M:%S").to_string();
+            let release_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
+            let latest_row_at = parse_time_string(latest_row_at_string)
+                .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
 
-            let should_take = release_beijing_str.as_str() > latest_row_at_string;
+            let should_take = release_beijing > latest_row_at;
 
             if should_take {
                 debug!(
                     "UP主「{}」增量获取：视频发布时间 {} > 上次扫描最新视频发布时间 {}",
-                    self.upper_name, release_beijing_str, latest_row_at_string
+                    self.upper_name,
+                    release_beijing.format("%Y-%m-%d %H:%M:%S"),
+                    latest_row_at.format("%Y-%m-%d %H:%M:%S")
                 );
             } else {
                 debug!(
                     "UP主「{}」增量跳过：视频发布时间 {} <= 上次扫描最新视频发布时间 {}",
-                    self.upper_name, release_beijing_str, latest_row_at_string
+                    self.upper_name,
+                    release_beijing.format("%Y-%m-%d %H:%M:%S"),
+                    latest_row_at.format("%Y-%m-%d %H:%M:%S")
                 );
             }
 
@@ -208,9 +213,9 @@ impl VideoSource for submission::Model {
         })
     }
 
-    fn get_created_at(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+    fn get_created_at(&self) -> Option<chrono::NaiveDateTime> {
         // 使用统一的时间解析函数
-        parse_time_string(&self.created_at).map(|dt| dt.and_utc()).or_else(|| {
+        parse_time_string(&self.created_at).or_else(|| {
             warn!("解析 created_at 时间失败，原始值: {}", self.created_at);
             None
         })

--- a/crates/bili_sync/src/adapter/submission.rs
+++ b/crates/bili_sync/src/adapter/submission.rs
@@ -57,14 +57,15 @@ impl VideoSource for submission::Model {
     }
 
     fn should_take(&self, release_datetime: &chrono::DateTime<Utc>, latest_row_at_string: &str) -> bool {
-        // 检查是否存在断点恢复情况
+        // 只有本轮扫描开始前已经存在的断点才算断点恢复。
+        // 同一轮扫描中每页结束保存的运行时断点不能绕过增量截止。
         let upper_id_str = self.upper_id.to_string();
-        let has_checkpoint = {
-            let tracker = crate::bilibili::submission::SUBMISSION_PAGE_TRACKER.read().unwrap();
-            tracker.contains_key(&upper_id_str)
+        let is_resuming_from_checkpoint = {
+            let tracker = crate::bilibili::submission::SUBMISSION_RESUME_TRACKER.read().unwrap();
+            tracker.contains(&upper_id_str)
         };
 
-        if has_checkpoint {
+        if is_resuming_from_checkpoint {
             return true;
         }
 

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use axum::extract::{Extension, Json, Path, Query};
 use axum::http::{header::IF_NONE_MATCH, HeaderMap};
 use axum::response::sse::{Event, KeepAlive, Sse};
-use chrono::{DateTime, Datelike, Utc};
+use chrono::{DateTime, Datelike, TimeZone, Utc};
 use html_escape::decode_html_entities;
 
 use crate::http::headers::{create_api_headers, create_image_headers};
@@ -9835,12 +9835,14 @@ fn config_for_filename_preview(params: FilenamePreviewRequest) -> crate::config:
 }
 
 fn preview_time(config: &crate::config::Config) -> String {
-    chrono::NaiveDate::from_ymd_opt(2026, 5, 13)
+    let preview_naive = chrono::NaiveDate::from_ymd_opt(2026, 5, 13)
         .and_then(|date| date.and_hms_opt(12, 34, 56))
-        .unwrap()
-        .and_utc()
-        .format(&config.time_format)
-        .to_string()
+        .unwrap();
+    crate::utils::time_format::beijing_timezone()
+        .from_local_datetime(&preview_naive)
+        .single()
+        .map(|dt| dt.format(&config.time_format).to_string())
+        .unwrap_or_else(|| preview_naive.format(&config.time_format).to_string())
 }
 
 fn preview_path(parts: &[&str]) -> String {

--- a/crates/bili_sync/src/bilibili/bangumi.rs
+++ b/crates/bili_sync/src/bilibili/bangumi.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use anyhow::{bail, Result};
 use async_stream::try_stream;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use futures::Stream;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
@@ -14,6 +14,16 @@ use super::{BiliClient, Validate, VideoInfo};
 /// 根据用户确认，section_type: 1 是最可靠的预告片标识
 fn is_preview_episode(episode: &serde_json::Value) -> bool {
     episode["section_type"].as_i64().unwrap_or(0) == 1
+}
+
+fn utc_datetime_to_beijing_naive(value: DateTime<Utc>) -> NaiveDateTime {
+    value
+        .with_timezone(&crate::utils::time_format::beijing_timezone())
+        .naive_local()
+}
+
+fn api_timestamp_to_beijing_naive(timestamp: i64) -> Option<NaiveDateTime> {
+    DateTime::<Utc>::from_timestamp(timestamp, 0).map(utc_datetime_to_beijing_naive)
 }
 
 /// 智能集数分配算法，解决特殊剧集集数冲突问题
@@ -122,14 +132,14 @@ impl Bangumi {
 
     /// 轻量级检查番剧是否有更新
     /// 返回 (是否有更新, 最新剧集时间)
-    pub async fn check_update(&self, last_check_time: Option<DateTime<Utc>>) -> Result<(bool, Option<DateTime<Utc>>)> {
+    pub async fn check_update(&self, last_check_time: Option<NaiveDateTime>) -> Result<(bool, Option<NaiveDateTime>)> {
         // 获取最小信息来判断是否有更新
         let season_info = self.get_season_info().await?;
 
         // 获取最新更新时间
         let latest_episode_time = season_info["new_ep"]["pub_time"]
             .as_i64()
-            .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0));
+            .and_then(api_timestamp_to_beijing_naive);
 
         // 如果没有上次检查时间，视为有更新
         let has_update = match (last_check_time, latest_episode_time) {
@@ -181,7 +191,7 @@ impl Bangumi {
     /// 将单季番剧转换为视频流（支持增量获取）
     pub fn to_video_stream_incremental(
         &self,
-        latest_row_at: Option<chrono::DateTime<chrono::Utc>>,
+        latest_row_at: Option<NaiveDateTime>,
     ) -> Pin<Box<dyn Stream<Item = Result<VideoInfo>> + Send>> {
         let client = self.client.clone();
         let season_id = self.season_id.clone();
@@ -283,12 +293,13 @@ impl Bangumi {
                 // 将发布时间戳转换为 DateTime<Utc>
                 let pub_time = DateTime::<Utc>::from_timestamp(pub_time_timestamp, 0)
                     .unwrap_or_else(Utc::now);
+                let pub_time_beijing = utc_datetime_to_beijing_naive(pub_time);
                 let duration = (_duration > 0).then_some((_duration / 1000) as i32);
 
                 // 增量获取：检查旧集数是否需要字段更新
                 if let Some(latest_time) = latest_row_at {
-                    if pub_time <= latest_time {
-                        tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time, latest_time);
+                    if pub_time_beijing <= latest_time {
+                        tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time_beijing, latest_time);
 
                         // 为旧集数构建 VideoInfo，用于后续的字段更新检查
                         let episode_title = if !show_title.is_empty() {
@@ -396,7 +407,7 @@ impl Bangumi {
     /// 将所有季度的番剧转换为视频流（支持增量获取）
     pub fn to_all_seasons_video_stream_incremental(
         &self,
-        latest_row_at: Option<chrono::DateTime<chrono::Utc>>,
+        latest_row_at: Option<NaiveDateTime>,
     ) -> Pin<Box<dyn Stream<Item = Result<VideoInfo>> + Send>> {
         let client = self.client.clone();
         let season_id = self.season_id.clone();
@@ -485,12 +496,13 @@ impl Bangumi {
                     // 将发布时间戳转换为 DateTime<Utc>
                     let pub_time = DateTime::<Utc>::from_timestamp(pub_time_timestamp, 0)
                         .unwrap_or_else(Utc::now);
+                    let pub_time_beijing = utc_datetime_to_beijing_naive(pub_time);
                     let duration = (_duration > 0).then_some((_duration / 1000) as i32);
 
                     // 增量获取：跳过早于latest_row_at的集数
                     if let Some(latest_time) = latest_row_at {
-                        if pub_time <= latest_time {
-                            tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time, latest_time);
+                        if pub_time_beijing <= latest_time {
+                            tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time_beijing, latest_time);
 
                             // 为旧集数构建 VideoInfo，用于后续的字段更新检查
                             let episode_title = if !show_title.is_empty() {
@@ -603,7 +615,7 @@ impl Bangumi {
     pub fn to_selected_seasons_video_stream_incremental(
         &self,
         selected_seasons: Vec<String>,
-        latest_row_at: Option<chrono::DateTime<chrono::Utc>>,
+        latest_row_at: Option<NaiveDateTime>,
     ) -> Pin<Box<dyn Stream<Item = Result<VideoInfo>> + Send>> {
         let client = self.client.clone();
         let media_id = self.media_id.clone();
@@ -795,12 +807,13 @@ impl Bangumi {
                     // 将发布时间戳转换为 DateTime<Utc>
                     let pub_time = DateTime::<Utc>::from_timestamp(pub_time_timestamp, 0)
                         .unwrap_or_else(Utc::now);
+                    let pub_time_beijing = utc_datetime_to_beijing_naive(pub_time);
                     let duration = (_duration > 0).then_some((_duration / 1000) as i32);
 
                     // 增量获取：跳过早于latest_row_at的集数
                     if let Some(latest_time) = latest_row_at {
-                        if pub_time <= latest_time {
-                            tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time, latest_time);
+                        if pub_time_beijing <= latest_time {
+                            tracing::trace!("检查旧集数字段更新需求：{} (发布时间: {}, 最新时间: {})", episode_title_raw, pub_time_beijing, latest_time);
 
                             // 为旧集数构建 VideoInfo，用于后续的字段更新检查
                             let episode_title = if !show_title.is_empty() {
@@ -907,5 +920,39 @@ impl Bangumi {
                 tracing::info!("选中季度番剧全量获取完成：处理了 {} 个季度，共 {} 集内容", seasons.len(), total_episodes);
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{NaiveDate, TimeZone};
+
+    #[test]
+    fn api_timestamp_to_beijing_naive_uses_utc_plus_eight() {
+        let timestamp = Utc.with_ymd_and_hms(2026, 6, 3, 14, 32, 31).unwrap().timestamp();
+
+        let parsed = api_timestamp_to_beijing_naive(timestamp).expect("timestamp should parse");
+
+        assert_eq!(
+            parsed,
+            NaiveDate::from_ymd_opt(2026, 6, 3)
+                .unwrap()
+                .and_hms_opt(22, 32, 31)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn incremental_cutoff_compares_api_time_as_beijing_naive() {
+        let latest_row_at = NaiveDate::from_ymd_opt(2026, 6, 3)
+            .unwrap()
+            .and_hms_opt(20, 52, 11)
+            .unwrap();
+        let timestamp = Utc.with_ymd_and_hms(2026, 6, 3, 14, 32, 31).unwrap().timestamp();
+
+        let api_time = api_timestamp_to_beijing_naive(timestamp).expect("timestamp should parse");
+
+        assert!(api_time > latest_row_at);
     }
 }

--- a/crates/bili_sync/src/bilibili/submission.rs
+++ b/crates/bili_sync/src/bilibili/submission.rs
@@ -5,7 +5,7 @@ use futures::Stream;
 use once_cell::sync::Lazy;
 use reqwest::Method;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -21,6 +21,7 @@ use crate::utils::submission_checkpoint;
 /// 存储格式: (页码, 该页已处理的视频索引)
 pub static SUBMISSION_PAGE_TRACKER: Lazy<RwLock<HashMap<String, (usize, usize)>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+pub static SUBMISSION_RESUME_TRACKER: Lazy<RwLock<HashSet<String>>> = Lazy::new(|| RwLock::new(HashSet::new()));
 
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct SubmissionAccountStatus {
@@ -152,7 +153,15 @@ impl<'a> Submission<'a> {
             };
 
             // 记录恢复信息
-            let _is_resuming_from_checkpoint = page > 1 || skip_videos_count > 0;
+            let is_resuming_from_checkpoint = page > 1 || skip_videos_count > 0;
+            {
+                let mut resume_tracker = SUBMISSION_RESUME_TRACKER.write().unwrap();
+                if is_resuming_from_checkpoint {
+                    resume_tracker.insert(self.upper_id.clone());
+                } else {
+                    resume_tracker.remove(&self.upper_id);
+                }
+            }
             let resume_page = page;  // 记录恢复的起始页码，用于判断是否需要跳过视频
             let mut current_skip_count = skip_videos_count;  // 当前页需要跳过的视频数
 
@@ -371,6 +380,10 @@ impl<'a> Submission<'a> {
             if tracker.remove(&self.upper_id).is_some() {
                 info!("清除UP主 {} 的断点（扫描完成）", self.upper_id);
             }
+        }
+        {
+            let mut resume_tracker = SUBMISSION_RESUME_TRACKER.write().unwrap();
+            resume_tracker.remove(&self.upper_id);
         }
 
         // 持久化到数据库（清除该UP主的断点）

--- a/crates/bili_sync/src/utils/bangumi_cache.rs
+++ b/crates/bili_sync/src/utils/bangumi_cache.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use sea_orm::sea_query::{Alias, ColumnDef, Table};
 use sea_orm::{ConnectionTrait, DbConn};
 use serde::{Deserialize, Serialize};
@@ -90,13 +90,27 @@ pub fn serialize_cache(cache: &BangumiCache) -> Result<String> {
 }
 
 /// 检查缓存是否过期（默认24小时）
-pub fn is_cache_expired(cache_updated_at: Option<DateTime<Utc>>, max_age_hours: i64) -> bool {
+pub fn is_cache_expired(cache_updated_at: Option<NaiveDateTime>, max_age_hours: i64) -> bool {
     match cache_updated_at {
         Some(updated_at) => {
-            let now = crate::utils::time_format::beijing_now();
+            let now = crate::utils::time_format::now_naive();
             let age = now.signed_duration_since(updated_at);
             age.num_hours() > max_age_hours
         }
         None => true, // 没有缓存时间，视为过期
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn cache_expiration_uses_beijing_naive_time() {
+        let now = crate::utils::time_format::now_naive();
+
+        assert!(!is_cache_expired(Some(now - Duration::hours(23)), 24));
+        assert!(is_cache_expired(Some(now - Duration::hours(25)), 24));
     }
 }

--- a/crates/bili_sync/src/utils/format_arg.rs
+++ b/crates/bili_sync/src/utils/format_arg.rs
@@ -1,8 +1,16 @@
-use chrono::Datelike;
+use chrono::{Datelike, TimeZone};
 use html_escape::decode_html_entities;
 use serde_json::json;
 
 use crate::config;
+
+fn format_stored_beijing_time(value: chrono::NaiveDateTime, format: &str) -> String {
+    crate::utils::time_format::beijing_timezone()
+        .from_local_datetime(&value)
+        .single()
+        .map(|dt| dt.format(format).to_string())
+        .unwrap_or_else(|| value.format(format).to_string())
+}
 
 /// 完全基于API的番剧标题提取，无硬编码回退逻辑
 fn extract_series_title_with_context(
@@ -116,8 +124,8 @@ pub fn video_format_args(video_model: &bili_sync_entity::video::Model) -> serde_
         "title": &video_model.name,
         "upper_name": decoded_upper_name,
         "upper_mid": &video_model.upper_id,
-        "pubtime": &video_model.pubtime.and_utc().format(&current_config.time_format).to_string(),
-        "fav_time": &video_model.favtime.and_utc().format(&current_config.time_format).to_string(),
+        "pubtime": &format_stored_beijing_time(video_model.pubtime, &current_config.time_format),
+        "fav_time": &format_stored_beijing_time(video_model.favtime, &current_config.time_format),
         "show_title": &video_model.name,
     })
 }
@@ -231,8 +239,8 @@ pub fn bangumi_page_format_args(
         "status": status,
         "ep_id": video_model.ep_id.as_deref().unwrap_or(""),
         "season_id": video_model.season_id.as_deref().unwrap_or(""),
-        "pubtime": video_model.pubtime.and_utc().format(&current_config.time_format).to_string(),
-        "fav_time": video_model.favtime.and_utc().format(&current_config.time_format).to_string(),
+        "pubtime": format_stored_beijing_time(video_model.pubtime, &current_config.time_format),
+        "fav_time": format_stored_beijing_time(video_model.favtime, &current_config.time_format),
         // 添加更多文件夹命名可能用到的变量
         "show_title": &video_model.name, // 番剧标题（别名）
         "series_title": &series_title, // 系列标题，从单集标题中提取
@@ -289,8 +297,8 @@ pub fn page_format_args(
             "share_copy": video_model.share_copy.as_deref().unwrap_or(""),
             "category": video_model.category,
             "resolution": resolution,
-            "pubtime": video_model.pubtime.and_utc().format(&current_config.time_format).to_string(),
-            "fav_time": video_model.favtime.and_utc().format(&current_config.time_format).to_string(),
+            "pubtime": format_stored_beijing_time(video_model.pubtime, &current_config.time_format),
+            "fav_time": format_stored_beijing_time(video_model.favtime, &current_config.time_format),
             "long_title": &page_model.name,
             "show_title": &page_model.name,
         })
@@ -307,8 +315,8 @@ pub fn page_format_args(
             "ptitle": &page_model.name,
             "pid": page_model.pid,
             "pid_pad": format!("{:02}", page_model.pid),
-            "pubtime": video_model.pubtime.and_utc().format(&current_config.time_format).to_string(),
-            "fav_time": video_model.favtime.and_utc().format(&current_config.time_format).to_string(),
+            "pubtime": format_stored_beijing_time(video_model.pubtime, &current_config.time_format),
+            "fav_time": format_stored_beijing_time(video_model.favtime, &current_config.time_format),
             "long_title": &page_model.name,
             "show_title": &page_model.name,
         })

--- a/crates/bili_sync/src/utils/model.rs
+++ b/crates/bili_sync/src/utils/model.rs
@@ -425,7 +425,8 @@ pub async fn create_videos(
                 // 获取创建时间来判断是否为新投稿
                 let is_new_submission = if let Some(created_at) = video_source.get_created_at() {
                     // 如果视频发布时间晚于订阅创建时间，则为新投稿，自动下载
-                    video_info.release_datetime() > &created_at
+                    let beijing_tz = crate::utils::time_format::beijing_timezone();
+                    video_info.release_datetime().with_timezone(&beijing_tz).naive_local() > created_at
                 } else {
                     // 如果无法获取创建时间，保守地认为不是新投稿
                     false
@@ -699,7 +700,8 @@ pub async fn create_videos(
                 // 获取创建时间来判断是否为新投稿
                 let is_new_submission = if let Some(created_at) = video_source.get_created_at() {
                     // 如果视频发布时间晚于订阅创建时间，则为新投稿，自动下载
-                    video_info.release_datetime() > &created_at
+                    let beijing_tz = crate::utils::time_format::beijing_timezone();
+                    video_info.release_datetime().with_timezone(&beijing_tz).naive_local() > created_at
                 } else {
                     // 如果无法获取创建时间，保守地认为不是新投稿
                     false
@@ -1587,6 +1589,83 @@ mod tests {
         let path = root.join(name);
         fs::write(&path, vec![b'x'; size]).expect("应能写入测试文件");
         path.to_string_lossy().to_string()
+    }
+
+    fn selective_submission_source(created_at: &str) -> VideoSourceEnum {
+        VideoSourceEnum::Submission(submission::Model {
+            id: 1,
+            upper_id: 1000,
+            upper_name: "测试UP".to_string(),
+            path: "/tmp/submission-selective".to_string(),
+            created_at: created_at.to_string(),
+            latest_row_at: "1970-01-01 00:00:00".to_string(),
+            enabled: true,
+            scan_deleted_videos: false,
+            scan_deleted_videos_once: false,
+            selected_videos: Some("[]".to_string()),
+            keyword_filters: None,
+            keyword_filter_mode: None,
+            blacklist_keywords: None,
+            whitelist_keywords: None,
+            keyword_case_sensitive: false,
+            min_duration_seconds: None,
+            max_duration_seconds: None,
+            published_after: None,
+            published_before: None,
+            audio_only: false,
+            audio_only_m4a_only: false,
+            flat_folder: false,
+            split_chapters_after_download: false,
+            download_danmaku: true,
+            download_subtitle: true,
+            ai_rename: false,
+            ai_rename_video_prompt: String::new(),
+            ai_rename_audio_prompt: String::new(),
+            ai_rename_enable_multi_page: false,
+            ai_rename_enable_collection: false,
+            ai_rename_enable_bangumi: false,
+            ai_rename_rename_parent_dir: false,
+            use_dynamic_api: false,
+            dynamic_api_full_synced: false,
+            last_scan_at: None,
+            next_scan_at: None,
+            no_update_streak: 0,
+        })
+    }
+
+    #[tokio::test]
+    async fn create_videos_treats_submission_created_at_as_beijing_time_for_selective_download() {
+        let db = create_test_db("selective-created-at-beijing").await;
+        let source = selective_submission_source("2026-06-03 20:52:11");
+        let video_time = chrono::DateTime::parse_from_rfc3339("2026-06-03T14:32:31Z")
+            .expect("测试时间应合法")
+            .with_timezone(&chrono::Utc);
+
+        create_videos(
+            vec![crate::bilibili::VideoInfo::Submission {
+                title: "订阅后新投稿".to_string(),
+                bvid: "BV1CreatedAtBeijing".to_string(),
+                intro: String::new(),
+                cover: String::new(),
+                ctime: video_time,
+                duration: Some(60),
+                season_id: None,
+            }],
+            &source,
+            &db,
+        )
+        .await
+        .expect("创建视频应成功");
+
+        let inserted_count = video::Entity::find()
+            .filter(video::Column::Bvid.eq("BV1CreatedAtBeijing"))
+            .count(&db)
+            .await
+            .expect("应能统计插入视频");
+        assert_eq!(
+            inserted_count, 1,
+            "北京时间 22:32:31 晚于订阅创建时间 20:52:11，应作为新投稿存储"
+        );
     }
 
     #[tokio::test]

--- a/crates/bili_sync/src/utils/submission_checkpoint.rs
+++ b/crates/bili_sync/src/utils/submission_checkpoint.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::bilibili::submission::SUBMISSION_PAGE_TRACKER;
+use crate::bilibili::submission::{SUBMISSION_PAGE_TRACKER, SUBMISSION_RESUME_TRACKER};
 
 const CHECKPOINT_KEY: &str = "submission_checkpoints";
 
@@ -44,6 +44,7 @@ pub async fn restore_checkpoints_from_db(db: &Arc<DatabaseConnection>) -> Result
             // 恢复到内存中的静态变量
             let mut tracker = SUBMISSION_PAGE_TRACKER.write().unwrap();
             *tracker = checkpoints.checkpoints;
+            SUBMISSION_RESUME_TRACKER.write().unwrap().clear();
 
             if !tracker.is_empty() {
                 info!("从数据库恢复 {} 个断点信息", tracker.len());
@@ -55,6 +56,7 @@ pub async fn restore_checkpoints_from_db(db: &Arc<DatabaseConnection>) -> Result
             }
         }
         None => {
+            SUBMISSION_RESUME_TRACKER.write().unwrap().clear();
             debug!("数据库中没有断点信息配置项");
         }
     }
@@ -121,6 +123,7 @@ pub async fn clear_submission_checkpoint(db: &Arc<DatabaseConnection>, upper_id:
         let mut tracker = SUBMISSION_PAGE_TRACKER.write().unwrap();
         tracker.remove(&upper_id_str).is_some()
     };
+    SUBMISSION_RESUME_TRACKER.write().unwrap().remove(&upper_id_str);
 
     if removed {
         info!("清除UP主 {} 的断点信息（删除视频源）", upper_id);

--- a/crates/bili_sync/src/utils/time_format.rs
+++ b/crates/bili_sync/src/utils/time_format.rs
@@ -79,6 +79,15 @@ pub fn parse_time_string(time_str: &str) -> Option<NaiveDateTime> {
     None
 }
 
+/// 将数据库中存储的北京时间 NaiveDateTime 转为 UTC。
+pub fn stored_beijing_naive_to_utc(value: NaiveDateTime) -> DateTime<Utc> {
+    beijing_timezone()
+        .from_local_datetime(&value)
+        .single()
+        .expect("固定北京时间偏移应始终能映射本地时间")
+        .with_timezone(&Utc)
+}
+
 /// 将 Unix 时间戳转换为标准格式字符串（北京时间）
 pub fn timestamp_to_beijing_string(timestamp: i64) -> String {
     match DateTime::from_timestamp(timestamp, 0) {

--- a/crates/bili_sync/src/utils/time_format.rs
+++ b/crates/bili_sync/src/utils/time_format.rs
@@ -34,6 +34,11 @@ pub fn now_naive() -> NaiveDateTime {
     truncated.naive_local()
 }
 
+pub fn beijing_epoch_naive() -> NaiveDateTime {
+    NaiveDateTime::parse_from_str("1970-01-01 00:00:00", STANDARD_TIME_FORMAT)
+        .expect("固定北京时间初始值应可解析")
+}
+
 /// 将任意时间转换为标准格式字符串
 pub fn to_standard_string<Tz: TimeZone>(dt: DateTime<Tz>) -> String
 where

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -1034,7 +1034,7 @@ async fn update_bangumi_cache(
                 "long_title": video.name.clone(),
                 "cover": video.cover.clone(),
                 "duration": page.duration as i64 * 1000, // 秒转毫秒
-                "pub_time": video.pubtime.and_utc().timestamp(),
+                "pub_time": crate::utils::time_format::stored_beijing_naive_to_utc(video.pubtime).timestamp(),
                 "section_type": 0, // 正片
             });
 
@@ -1079,7 +1079,10 @@ async fn update_bangumi_cache(
     });
 
     // 获取最新的剧集时间
-    let last_episode_time = videos_with_pages.iter().map(|(v, _)| v.pubtime.and_utc()).max();
+    let last_episode_time = videos_with_pages
+        .iter()
+        .map(|(v, _)| crate::utils::time_format::stored_beijing_naive_to_utc(v.pubtime))
+        .max();
 
     // 创建缓存对象
     let cache = BangumiCache {
@@ -1125,9 +1128,9 @@ pub async fn refresh_video_source<'a>(
     video_source.log_refresh_video_start();
     let latest_row_at_string = video_source.get_latest_row_at();
     let latest_row_at = crate::utils::time_format::parse_time_string(&latest_row_at_string)
-        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc())
-        .and_utc();
+        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
     let mut max_datetime = latest_row_at;
+    let beijing_tz = crate::utils::time_format::beijing_timezone();
 
     async fn ingest_batch(
         video_source: &VideoSourceEnum,
@@ -1297,8 +1300,9 @@ pub async fn refresh_video_source<'a>(
         // 此时获取到的第二页视频比第一页的还要新，因此为了确保正确，理应对每一页的第一个视频进行时间比较
         // 但在 streams 的抽象下，无法判断具体是在哪里分页的，所以暂且对每个视频都进行比较，应该不会有太大性能损失
         let release_datetime = video_info.release_datetime();
-        if release_datetime > &max_datetime {
-            max_datetime = *release_datetime;
+        let release_datetime_beijing = release_datetime.with_timezone(&beijing_tz).naive_local();
+        if release_datetime_beijing > max_datetime {
+            max_datetime = release_datetime_beijing;
         }
 
         // 增量截断：遇到旧视频则结束扫描
@@ -1322,9 +1326,7 @@ pub async fn refresh_video_source<'a>(
         ingest_batch(video_source, connection, videos_info, &mut count, &mut new_videos).await?;
     }
     if max_datetime != latest_row_at {
-        // 转换为北京时间的标准字符串格式
-        let beijing_datetime = max_datetime.with_timezone(&crate::utils::time_format::beijing_timezone());
-        let beijing_datetime_string = beijing_datetime.format("%Y-%m-%d %H:%M:%S").to_string();
+        let beijing_datetime_string = max_datetime.format("%Y-%m-%d %H:%M:%S").to_string();
         video_source
             .update_latest_row_at(beijing_datetime_string)
             .save(connection)
@@ -13849,6 +13851,61 @@ mod tests {
             .expect("投稿源应存在");
         assert!(updated_submission.scan_deleted_videos);
         assert!(!updated_submission.scan_deleted_videos_once);
+    }
+
+    #[tokio::test]
+    async fn test_refresh_video_source_advances_submission_latest_row_at_with_beijing_time() {
+        let db = create_test_db("submission-latest-row-beijing").await;
+        insert_test_submission(&db, 1, false, false).await;
+
+        let mut update_model = submission::ActiveModel {
+            id: Set(1),
+            ..Default::default()
+        };
+        update_model.created_at = Set("2026-06-04 00:00:00".to_string());
+        update_model.latest_row_at = Set("2026-06-03 20:52:11".to_string());
+        update_model.selected_videos = Set(Some("[]".to_string()));
+        update_model.update(&db).await.expect("应能更新测试投稿源");
+
+        let submission_source = submission::Entity::find_by_id(1)
+            .one(&db)
+            .await
+            .expect("查询应成功")
+            .expect("投稿源应存在");
+        let video_source = VideoSourceEnum::Submission(submission_source);
+        let video_time = chrono::DateTime::parse_from_rfc3339("2026-06-03T14:32:31Z")
+            .expect("测试时间应合法")
+            .with_timezone(&chrono::Utc);
+        let video_stream = futures::stream::iter(vec![Ok(crate::bilibili::VideoInfo::Submission {
+            title: "选择性下载会跳过的视频".to_string(),
+            bvid: "BV1SkippedBySelection".to_string(),
+            intro: String::new(),
+            cover: String::new(),
+            ctime: video_time,
+            duration: Some(60),
+            season_id: None,
+        })]);
+        let bili_client = BiliClient::new(String::new());
+
+        let (count, new_videos) = refresh_video_source(
+            &video_source,
+            Box::pin(video_stream),
+            &db,
+            CancellationToken::new(),
+            &bili_client,
+        )
+        .await
+        .expect("刷新投稿源应成功");
+
+        assert_eq!(count, 0, "选择性下载过滤的视频不应被存储");
+        assert!(new_videos.is_empty(), "选择性下载过滤的视频不应生成新视频通知");
+
+        let updated_submission = submission::Entity::find_by_id(1)
+            .one(&db)
+            .await
+            .expect("查询应成功")
+            .expect("投稿源应存在");
+        assert_eq!(updated_submission.latest_row_at, "2026-06-03 22:32:31");
     }
 
     #[test]

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -13908,6 +13908,94 @@ mod tests {
         assert_eq!(updated_submission.latest_row_at, "2026-06-03 22:32:31");
     }
 
+    #[tokio::test]
+    async fn test_refresh_video_source_does_not_treat_same_run_page_checkpoint_as_resume() {
+        let db = create_test_db("submission-runtime-checkpoint").await;
+        insert_test_submission(&db, 1, false, false).await;
+
+        let mut update_model = submission::ActiveModel {
+            id: Set(1),
+            ..Default::default()
+        };
+        update_model.latest_row_at = Set("2026-06-20 18:00:00".to_string());
+        update_model.update(&db).await.expect("should update test submission");
+
+        let submission_source = submission::Entity::find_by_id(1)
+            .one(&db)
+            .await
+            .expect("query should succeed")
+            .expect("submission should exist");
+        let upper_id = submission_source.upper_id.to_string();
+        let video_source = VideoSourceEnum::Submission(submission_source);
+
+        {
+            let mut tracker = crate::bilibili::submission::SUBMISSION_PAGE_TRACKER.write().unwrap();
+            tracker.remove(&upper_id);
+        }
+        {
+            let mut tracker = crate::bilibili::submission::SUBMISSION_RESUME_TRACKER.write().unwrap();
+            tracker.remove(&upper_id);
+        }
+
+        let upper_id_for_stream = upper_id.clone();
+        let video_stream = futures::stream::iter((0..31).map(move |idx| {
+            if idx == 30 {
+                let mut tracker = crate::bilibili::submission::SUBMISSION_PAGE_TRACKER.write().unwrap();
+                tracker.insert(upper_id_for_stream.clone(), (2, 0));
+            }
+
+            let timestamp = if idx < 30 {
+                format!("2026-06-20T10:{:02}:00Z", idx + 1)
+            } else {
+                "2026-06-20T09:00:00Z".to_string()
+            };
+            let ctime = chrono::DateTime::parse_from_rfc3339(&timestamp)
+                .expect("test timestamp should parse")
+                .with_timezone(&chrono::Utc);
+
+            Ok(crate::bilibili::VideoInfo::Submission {
+                title: format!("checkpoint regression {idx}"),
+                bvid: format!("BVCheckpointRegression{idx:02}"),
+                intro: String::new(),
+                cover: String::new(),
+                ctime,
+                duration: Some(60),
+                season_id: None,
+            })
+        }));
+        let bili_client = BiliClient::new(String::new());
+
+        let (count, _) = refresh_video_source(
+            &video_source,
+            Box::pin(video_stream),
+            &db,
+            CancellationToken::new(),
+            &bili_client,
+        )
+        .await
+        .expect("refresh should succeed");
+
+        assert_eq!(count, 30, "old video after a runtime checkpoint should stop the scan");
+        let old_video_count = video::Entity::find()
+            .filter(video::Column::Bvid.eq("BVCheckpointRegression30"))
+            .count(&db)
+            .await
+            .expect("count should succeed");
+        assert_eq!(
+            old_video_count, 0,
+            "old video after a runtime checkpoint should not be stored"
+        );
+
+        {
+            let mut tracker = crate::bilibili::submission::SUBMISSION_PAGE_TRACKER.write().unwrap();
+            tracker.remove(&upper_id);
+        }
+        {
+            let mut tracker = crate::bilibili::submission::SUBMISSION_RESUME_TRACKER.write().unwrap();
+            tracker.remove(&upper_id);
+        }
+    }
+
     #[test]
     fn test_is_bili_request_failed_inaccessible_matches_deleted_and_invisible_codes() {
         let deleted_err = anyhow!(crate::bilibili::BiliError::RequestFailed(-404, "not found".to_string()));

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -1128,7 +1128,7 @@ pub async fn refresh_video_source<'a>(
     video_source.log_refresh_video_start();
     let latest_row_at_string = video_source.get_latest_row_at();
     let latest_row_at = crate::utils::time_format::parse_time_string(&latest_row_at_string)
-        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap().naive_utc());
+        .unwrap_or_else(crate::utils::time_format::beijing_epoch_naive);
     let mut max_datetime = latest_row_at;
     let beijing_tz = crate::utils::time_format::beijing_timezone();
 


### PR DESCRIPTION
## 概要
- 扫描进度相关的业务比较统一使用北京时间 `NaiveDateTime`，数据库里的北京时间字符串不再先转成 UTC 再比较。
- B 站/API 返回的时间只在进入业务比较前转换为北京时间 naive 时间；外部时间戳边界仍保持原本类型。
- 补充 `beijing_epoch_naive()` 作为扫描/缓存比较的初始值兜底，避免用 UTC naive 作为业务比较兜底。
- 修复投稿扫描里的运行时断点误判：同一轮扫描每页结束保存的页码断点不再被当成“断点恢复”，避免第 1 页全是新视频后第 2 页开始绕过 `latest_row_at` 截止并扫到底。

## 针对日志的结论
- `挑影工` 日志里的旧问题是水位停在 `2026-06-03 20:52:11`，本轮看到的视频更新但又被选择性下载过滤，导致旧版本不会推进 `latest_row_at`。
- `PantyhoseMaster` 的“有更新就扫到第 130 页”还有第二个根因：第一页 30 条都比旧水位新时，分页器保存了 `(page=2,index=0)` 运行时断点，旧代码的 `should_take()` 看到断点就直接放行，从第 2 页开始不再做增量截止。
- 本 PR 现在同时覆盖这两类情况：过滤后无入库也推进水位；运行时断点不再绕过同一轮增量截止，但真正从已有断点恢复时仍保留恢复能力。

## 测试
- `cargo test -p bili_sync test_refresh_video_source_does_not_treat_same_run_page_checkpoint_as_resume -- --nocapture`
- `cargo test -p bili_sync beijing_naive -- --nocapture`
- `cargo test -p bili_sync test_refresh_video_source_advances_submission_latest_row_at_with_beijing_time -- --nocapture`
- `cargo test -p bili_sync create_videos_treats_submission_created_at_as_beijing_time_for_selective_download -- --nocapture`
- `cargo check -p bili_sync`

## 全量测试说明
- 本地跑过 `cargo test -p bili_sync -- --nocapture`：212 个通过，仍有 1 个既有失败 `config::bundle::tests::test_video_template_path_separator_handling`。