### PR TITLE
feat: 添加视频源级流过滤设置

### DIFF
--- a/crates/bili_sync/src/adapter/bangumi.rs
+++ b/crates/bili_sync/src/adapter/bangumi.rs
@@ -40,6 +40,7 @@ pub struct BangumiSource {
     pub max_duration_seconds: Option<i32>,
     pub published_after: Option<String>,
     pub published_before: Option<String>,
+    pub filter_option: Option<serde_json::Value>,
     pub audio_only: bool,
     pub audio_only_m4a_only: bool,
     pub flat_folder: bool,
@@ -545,6 +546,10 @@ impl VideoSource for BangumiSource {
 
     fn get_published_before(&self) -> Option<String> {
         self.published_before.clone()
+    }
+
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        self.filter_option.as_ref()
     }
 
     fn audio_only(&self) -> bool {

--- a/crates/bili_sync/src/adapter/collection.rs
+++ b/crates/bili_sync/src/adapter/collection.rs
@@ -141,6 +141,10 @@ impl VideoSource for collection::Model {
         self.published_before.clone()
     }
 
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        self.filter_option.as_ref()
+    }
+
     fn audio_only(&self) -> bool {
         self.audio_only
     }

--- a/crates/bili_sync/src/adapter/favorite.rs
+++ b/crates/bili_sync/src/adapter/favorite.rs
@@ -140,6 +140,10 @@ impl VideoSource for favorite::Model {
         self.published_before.clone()
     }
 
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        self.filter_option.as_ref()
+    }
+
     fn audio_only(&self) -> bool {
         self.audio_only
     }

--- a/crates/bili_sync/src/adapter/mod.rs
+++ b/crates/bili_sync/src/adapter/mod.rs
@@ -160,6 +160,11 @@ pub trait VideoSource {
         None
     }
 
+    /// 获取视频源级流过滤配置；None 表示继承全局配置
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        None
+    }
+
     /// 获取是否仅下载音频（默认为 false）
     fn audio_only(&self) -> bool {
         false // 默认实现：下载视频
@@ -518,6 +523,7 @@ pub async fn bangumi_from<'a>(
             max_duration_seconds: model.max_duration_seconds,
             published_after: model.published_after,
             published_before: model.published_before,
+            filter_option: model.filter_option,
             audio_only: model.audio_only,
             audio_only_m4a_only: model.audio_only_m4a_only,
             flat_folder: model.flat_folder,
@@ -566,6 +572,7 @@ pub async fn bangumi_from<'a>(
             max_duration_seconds: None,
             published_after: None,
             published_before: None,
+            filter_option: None,
             audio_only: false,
             audio_only_m4a_only: false,
             flat_folder: false,

--- a/crates/bili_sync/src/adapter/submission.rs
+++ b/crates/bili_sync/src/adapter/submission.rs
@@ -266,6 +266,10 @@ impl VideoSource for submission::Model {
         self.published_before.clone()
     }
 
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        self.filter_option.as_ref()
+    }
+
     fn audio_only(&self) -> bool {
         self.audio_only
     }

--- a/crates/bili_sync/src/adapter/watch_later.rs
+++ b/crates/bili_sync/src/adapter/watch_later.rs
@@ -119,6 +119,10 @@ impl VideoSource for watch_later::Model {
         self.published_before.clone()
     }
 
+    fn filter_option(&self) -> Option<&serde_json::Value> {
+        self.filter_option.as_ref()
+    }
+
     fn audio_only(&self) -> bool {
         self.audio_only
     }

--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -48,7 +48,7 @@ use crate::api::response::{
     VideoSourcesResponse, VideosResponse,
 };
 use crate::api::wrapper::{ApiError, ApiResponse};
-use crate::bilibili::DEFAULT_AI_SUBTITLE_LANGUAGE;
+use crate::bilibili::{FilterOption, DEFAULT_AI_SUBTITLE_LANGUAGE};
 use crate::utils::live_updates::{
     notify_video_sources_changed, notify_videos_changed, subscribe_queue_status_changed,
     subscribe_video_sources_changed, subscribe_videos_changed,
@@ -74,6 +74,29 @@ fn ai_subtitle_language_from_request(language: &Option<String>, fallback: &str) 
         .as_deref()
         .map(normalize_ai_subtitle_language)
         .unwrap_or_else(|| normalize_ai_subtitle_language(fallback))
+}
+
+fn resolve_source_filter_option_update(
+    current: Option<serde_json::Value>,
+    requested: &Option<Option<FilterOption>>,
+) -> Result<Option<serde_json::Value>, ApiError> {
+    match requested {
+        Some(Some(filter_option)) => Ok(Some(serde_json::to_value(filter_option)?)),
+        Some(None) => Ok(None),
+        None => Ok(current),
+    }
+}
+
+fn source_filter_option_to_response(value: Option<serde_json::Value>) -> Result<Option<FilterOption>, ApiError> {
+    value.map(serde_json::from_value).transpose().map_err(ApiError::from)
+}
+
+fn source_filter_option_to_json(value: &Option<FilterOption>) -> Result<Option<serde_json::Value>, ApiError> {
+    value
+        .as_ref()
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(ApiError::from)
 }
 
 // 全局静态的扫码登录服务实例
@@ -2246,6 +2269,7 @@ pub async fn get_video_sources(
                 latest_row_at: normalize_video_source_latest_row_at(&model.latest_row_at),
                 scan_deleted_videos: model.scan_deleted_videos,
                 scan_deleted_videos_once: model.scan_deleted_videos_once,
+                filter_option: model.filter_option.and_then(|value| serde_json::from_value(value).ok()),
                 f_id: None,
                 s_id: Some(model.s_id),
                 m_id: Some(model.m_id),
@@ -2310,6 +2334,7 @@ pub async fn get_video_sources(
                 latest_row_at: normalize_video_source_latest_row_at(&model.latest_row_at),
                 scan_deleted_videos: model.scan_deleted_videos,
                 scan_deleted_videos_once: model.scan_deleted_videos_once,
+                filter_option: model.filter_option.and_then(|value| serde_json::from_value(value).ok()),
                 f_id: Some(model.f_id),
                 s_id: None,
                 m_id: None,
@@ -2374,6 +2399,7 @@ pub async fn get_video_sources(
                 latest_row_at: normalize_video_source_latest_row_at(&model.latest_row_at),
                 scan_deleted_videos: model.scan_deleted_videos,
                 scan_deleted_videos_once: model.scan_deleted_videos_once,
+                filter_option: model.filter_option.and_then(|value| serde_json::from_value(value).ok()),
                 f_id: None,
                 s_id: None,
                 m_id: None,
@@ -2438,6 +2464,7 @@ pub async fn get_video_sources(
                 latest_row_at: normalize_video_source_latest_row_at(&model.latest_row_at),
                 scan_deleted_videos: model.scan_deleted_videos,
                 scan_deleted_videos_once: model.scan_deleted_videos_once,
+                filter_option: model.filter_option.and_then(|value| serde_json::from_value(value).ok()),
                 f_id: None,
                 s_id: None,
                 m_id: None,
@@ -2521,6 +2548,7 @@ pub async fn get_video_sources(
                 latest_row_at: normalize_video_source_latest_row_at(&model.latest_row_at),
                 scan_deleted_videos: model.scan_deleted_videos,
                 scan_deleted_videos_once: model.scan_deleted_videos_once,
+                filter_option: model.filter_option.and_then(|value| serde_json::from_value(value).ok()),
                 f_id: None,
                 s_id: None,
                 m_id: None,
@@ -4595,6 +4623,7 @@ pub async fn add_video_source(
             up_id: params.up_id.clone(),
             collection_type: params.collection_type.clone(),
             collection_aggregate_enabled: params.collection_aggregate_enabled,
+            filter_option: params.filter_option.clone(),
             media_id: params.media_id.clone(),
             ep_id: params.ep_id.clone(),
             download_all_seasons: params.download_all_seasons,
@@ -4634,6 +4663,7 @@ pub async fn add_video_source_internal(
     let txn = crate::database::begin_traced_transaction(&db, "api.handler.add_video_source").await?;
     let ai_subtitle_language =
         ai_subtitle_language_from_request(&params.ai_subtitle_language, DEFAULT_AI_SUBTITLE_LANGUAGE);
+    let source_filter_option = source_filter_option_to_json(&params.filter_option)?;
 
     let result = match params.source_type.as_str() {
         "collection" => {
@@ -4744,6 +4774,7 @@ pub async fn add_video_source_internal(
                 enabled: sea_orm::Set(true),
                 scan_deleted_videos: sea_orm::Set(false),
                 scan_deleted_videos_once: sea_orm::Set(false),
+                filter_option: sea_orm::Set(source_filter_option.clone()),
                 cover: sea_orm::Set(cover_url),
                 keyword_filters: sea_orm::Set(keyword_filters_json),
                 keyword_filter_mode: sea_orm::Set(keyword_filter_mode),
@@ -4852,6 +4883,7 @@ pub async fn add_video_source_internal(
                 enabled: sea_orm::Set(true),
                 scan_deleted_videos: sea_orm::Set(false),
                 scan_deleted_videos_once: sea_orm::Set(false),
+                filter_option: sea_orm::Set(source_filter_option.clone()),
                 keyword_filters: sea_orm::Set(keyword_filters_json),
                 keyword_filter_mode: sea_orm::Set(keyword_filter_mode),
                 blacklist_keywords: sea_orm::Set(None),
@@ -4933,6 +4965,7 @@ pub async fn add_video_source_internal(
                 last_scan_at: sea_orm::Set(None),
                 next_scan_at: sea_orm::Set(None),
                 no_update_streak: sea_orm::Set(0),
+                filter_option: sea_orm::Set(source_filter_option.clone()),
                 selected_videos: sea_orm::Set(
                     params
                         .selected_videos
@@ -5108,6 +5141,17 @@ pub async fn add_video_source_internal(
                     merge_message.push_str(&format!("番剧名称已更新为: {}", params.name));
                 }
 
+                // 更新源级流过滤配置（如果添加请求携带了自定义配置）
+                if source_filter_option.is_some() && source_filter_option != existing.filter_option {
+                    existing.filter_option = source_filter_option.clone();
+                    updated = true;
+
+                    if !merge_message.is_empty() {
+                        merge_message.push('，');
+                    }
+                    merge_message.push_str("源级码率设置已更新");
+                }
+
                 if updated {
                     // 更新数据库记录 - 修复：正确使用ActiveModel更新
                     let mut existing_update = video_source::ActiveModel {
@@ -5137,6 +5181,10 @@ pub async fn add_video_source_internal(
                     // 更新名称（如果有变更）
                     if !params.name.is_empty() && params.name != existing.name {
                         existing_update.name = sea_orm::Set(params.name.clone());
+                    }
+
+                    if source_filter_option.is_some() {
+                        existing_update.filter_option = sea_orm::Set(source_filter_option.clone());
                     }
 
                     video_source::Entity::update(existing_update).exec(&txn).await?;
@@ -5261,6 +5309,7 @@ pub async fn add_video_source_internal(
                     ep_id: sea_orm::Set(params.ep_id),
                     scan_deleted_videos: sea_orm::Set(false),
                     scan_deleted_videos_once: sea_orm::Set(false),
+                    filter_option: sea_orm::Set(source_filter_option.clone()),
                     download_all_seasons: sea_orm::Set(Some(download_all_seasons)),
                     selected_seasons: sea_orm::Set(selected_seasons_json),
                     keyword_filters: sea_orm::Set(keyword_filters_json),
@@ -5341,6 +5390,7 @@ pub async fn add_video_source_internal(
                 enabled: sea_orm::Set(true),
                 scan_deleted_videos: sea_orm::Set(false),
                 scan_deleted_videos_once: sea_orm::Set(false),
+                filter_option: sea_orm::Set(source_filter_option.clone()),
                 keyword_filters: sea_orm::Set(keyword_filters_json),
                 keyword_filter_mode: sea_orm::Set(keyword_filter_mode),
                 blacklist_keywords: sea_orm::Set(None),
@@ -7765,6 +7815,9 @@ pub async fn update_video_source_download_options_internal(
             let ai_rename_rename_parent_dir = params
                 .ai_rename_rename_parent_dir
                 .unwrap_or(collection.ai_rename_rename_parent_dir);
+            let filter_option =
+                resolve_source_filter_option_update(collection.filter_option.clone(), &params.filter_option)?;
+            let response_filter_option = source_filter_option_to_response(filter_option.clone())?;
 
             collection::Entity::update(collection::ActiveModel {
                 id: sea_orm::ActiveValue::Unchanged(id),
@@ -7785,6 +7838,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_collection: sea_orm::Set(ai_rename_enable_collection),
                 ai_rename_enable_bangumi: sea_orm::Set(ai_rename_enable_bangumi),
                 ai_rename_rename_parent_dir: sea_orm::Set(ai_rename_rename_parent_dir),
+                filter_option: sea_orm::Set(filter_option),
                 ..Default::default()
             })
             .exec(&txn)
@@ -7812,6 +7866,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_bangumi,
                 ai_rename_rename_parent_dir,
                 use_dynamic_api: false,
+                filter_option: response_filter_option,
                 message: format!("合集 {} 的下载选项已更新", collection.name),
             }
         }
@@ -7853,6 +7908,9 @@ pub async fn update_video_source_download_options_internal(
             let ai_rename_rename_parent_dir = params
                 .ai_rename_rename_parent_dir
                 .unwrap_or(favorite.ai_rename_rename_parent_dir);
+            let filter_option =
+                resolve_source_filter_option_update(favorite.filter_option.clone(), &params.filter_option)?;
+            let response_filter_option = source_filter_option_to_response(filter_option.clone())?;
 
             favorite::Entity::update(favorite::ActiveModel {
                 id: sea_orm::ActiveValue::Unchanged(id),
@@ -7871,6 +7929,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_collection: sea_orm::Set(ai_rename_enable_collection),
                 ai_rename_enable_bangumi: sea_orm::Set(ai_rename_enable_bangumi),
                 ai_rename_rename_parent_dir: sea_orm::Set(ai_rename_rename_parent_dir),
+                filter_option: sea_orm::Set(filter_option),
                 ..Default::default()
             })
             .exec(&txn)
@@ -7898,6 +7957,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_bangumi,
                 ai_rename_rename_parent_dir,
                 use_dynamic_api: false,
+                filter_option: response_filter_option,
                 message: format!("收藏夹 {} 的下载选项已更新", favorite.name),
             }
         }
@@ -7940,6 +8000,9 @@ pub async fn update_video_source_download_options_internal(
                 .ai_rename_rename_parent_dir
                 .unwrap_or(submission.ai_rename_rename_parent_dir);
             let use_dynamic_api = params.use_dynamic_api.unwrap_or(submission.use_dynamic_api);
+            let filter_option =
+                resolve_source_filter_option_update(submission.filter_option.clone(), &params.filter_option)?;
+            let response_filter_option = source_filter_option_to_response(filter_option.clone())?;
             let mut dynamic_api_full_synced = submission.dynamic_api_full_synced;
             let mut latest_row_at_override: Option<String> = None;
 
@@ -7971,6 +8034,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_rename_parent_dir: sea_orm::Set(ai_rename_rename_parent_dir),
                 use_dynamic_api: sea_orm::Set(use_dynamic_api),
                 dynamic_api_full_synced: sea_orm::Set(dynamic_api_full_synced),
+                filter_option: sea_orm::Set(filter_option),
                 ..Default::default()
             };
 
@@ -8002,6 +8066,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_bangumi,
                 ai_rename_rename_parent_dir,
                 use_dynamic_api,
+                filter_option: response_filter_option,
                 message: format!("UP主投稿 {} 的下载选项已更新", submission.upper_name),
             }
         }
@@ -8043,6 +8108,9 @@ pub async fn update_video_source_download_options_internal(
             let ai_rename_rename_parent_dir = params
                 .ai_rename_rename_parent_dir
                 .unwrap_or(watch_later.ai_rename_rename_parent_dir);
+            let filter_option =
+                resolve_source_filter_option_update(watch_later.filter_option.clone(), &params.filter_option)?;
+            let response_filter_option = source_filter_option_to_response(filter_option.clone())?;
 
             watch_later::Entity::update(watch_later::ActiveModel {
                 id: sea_orm::ActiveValue::Unchanged(id),
@@ -8061,6 +8129,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_collection: sea_orm::Set(ai_rename_enable_collection),
                 ai_rename_enable_bangumi: sea_orm::Set(ai_rename_enable_bangumi),
                 ai_rename_rename_parent_dir: sea_orm::Set(ai_rename_rename_parent_dir),
+                filter_option: sea_orm::Set(filter_option),
                 ..Default::default()
             })
             .exec(&txn)
@@ -8088,6 +8157,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_bangumi,
                 ai_rename_rename_parent_dir,
                 use_dynamic_api: false,
+                filter_option: response_filter_option,
                 message: "稍后观看的下载选项已更新".to_string(),
             }
         }
@@ -8129,6 +8199,9 @@ pub async fn update_video_source_download_options_internal(
             let ai_rename_rename_parent_dir = params
                 .ai_rename_rename_parent_dir
                 .unwrap_or(video_source.ai_rename_rename_parent_dir);
+            let filter_option =
+                resolve_source_filter_option_update(video_source.filter_option.clone(), &params.filter_option)?;
+            let response_filter_option = source_filter_option_to_response(filter_option.clone())?;
 
             video_source::Entity::update(video_source::ActiveModel {
                 id: sea_orm::ActiveValue::Unchanged(id),
@@ -8147,6 +8220,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_collection: sea_orm::Set(ai_rename_enable_collection),
                 ai_rename_enable_bangumi: sea_orm::Set(ai_rename_enable_bangumi),
                 ai_rename_rename_parent_dir: sea_orm::Set(ai_rename_rename_parent_dir),
+                filter_option: sea_orm::Set(filter_option),
                 ..Default::default()
             })
             .exec(&txn)
@@ -8174,6 +8248,7 @@ pub async fn update_video_source_download_options_internal(
                 ai_rename_enable_bangumi,
                 ai_rename_rename_parent_dir,
                 use_dynamic_api: false,
+                filter_option: response_filter_option,
                 message: format!("番剧 {} 的下载选项已更新", video_source.name),
             }
         }

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use utoipa::IntoParams;
 use utoipa::ToSchema;
 
+use crate::bilibili::FilterOption;
+
 #[derive(Clone, Deserialize, IntoParams, Default)]
 pub struct VideosRequest {
     pub collection: Option<i32>,
@@ -45,6 +47,9 @@ pub struct AddVideoSourceRequest {
     pub collection_type: Option<String>,
     // 是否启用合集聚合（仅当source_type为"collection"时有效）
     pub collection_aggregate_enabled: Option<bool>,
+    /// 视频源级流过滤配置；缺失或 null 表示继承全局配置
+    #[serde(default)]
+    pub filter_option: Option<FilterOption>,
     // 番剧特有字段
     pub media_id: Option<String>,
     pub ep_id: Option<String>,
@@ -152,6 +157,9 @@ pub struct UpdateVideoSourceDownloadOptionsRequest {
     pub use_dynamic_api: Option<bool>,
     /// 是否启用合集聚合（仅collection有效）
     pub collection_aggregate_enabled: Option<bool>,
+    /// 视频源级流过滤配置：字段缺失保持不变，null 表示继承全局，对象表示使用自定义配置
+    #[serde(default)]
+    pub filter_option: Option<Option<FilterOption>>,
 }
 
 // 更新投稿源选中视频列表的请求结构体

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -2,6 +2,7 @@ use sea_orm::FromQueryResult;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use crate::bilibili::FilterOption;
 use crate::utils::status::{PageStatus, VideoStatus};
 
 #[derive(Debug, Serialize, ToSchema, Default)]
@@ -176,6 +177,7 @@ pub struct UpdateVideoSourceDownloadOptionsResponse {
     pub ai_rename_enable_bangumi: bool,
     pub ai_rename_rename_parent_dir: bool,
     pub use_dynamic_api: bool,
+    pub filter_option: Option<FilterOption>,
     pub message: String,
 }
 
@@ -279,6 +281,8 @@ pub struct VideoSource {
     pub ai_rename_enable_collection: bool,   // 对合集视频启用AI重命名
     pub ai_rename_enable_bangumi: bool,      // 对番剧启用AI重命名
     pub ai_rename_rename_parent_dir: bool,   // AI重命名时重命名上级目录
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_option: Option<FilterOption>, // 视频源级流过滤配置，None 表示继承全局
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_dynamic_api: Option<bool>, // 投稿源：是否使用动态API
 }

--- a/crates/bili_sync/src/bilibili/analyzer.rs
+++ b/crates/bili_sync/src/bilibili/analyzer.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::bilibili::error::BiliError;
 
@@ -8,7 +9,18 @@ pub struct PageAnalyzer {
 }
 
 #[derive(
-    Debug, strum::FromRepr, strum::EnumString, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Clone, Copy,
+    Debug,
+    strum::FromRepr,
+    strum::EnumString,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    ToSchema,
 )]
 pub enum VideoQuality {
     Quality360p = 16,
@@ -40,7 +52,7 @@ impl std::fmt::Display for VideoQuality {
     }
 }
 
-#[derive(Debug, Clone, Copy, strum::FromRepr, strum::EnumString, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, strum::FromRepr, strum::EnumString, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub enum AudioQuality {
     Quality64k = 30216,
     Quality132k = 30232,
@@ -84,6 +96,7 @@ impl AudioQuality {
     Deserialize,
     Clone,
     Copy,
+    ToSchema,
 )]
 pub enum VideoCodecs {
     #[strum(serialize = "HEV")]
@@ -109,7 +122,7 @@ impl TryFrom<u64> for VideoCodecs {
 }
 
 // 视频流的筛选偏好
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct FilterOption {
     pub video_max_quality: VideoQuality,
     pub video_min_quality: VideoQuality,

--- a/crates/bili_sync/src/task/mod.rs
+++ b/crates/bili_sync/src/task/mod.rs
@@ -49,6 +49,8 @@ pub struct AddVideoSourceTask {
     pub up_id: Option<String>,
     pub collection_type: Option<String>,
     pub collection_aggregate_enabled: Option<bool>,
+    #[serde(default)]
+    pub filter_option: Option<crate::bilibili::FilterOption>,
     pub media_id: Option<String>,
     pub ep_id: Option<String>,
     pub download_all_seasons: Option<bool>,
@@ -1857,6 +1859,7 @@ impl AddTaskQueue {
                 up_id: task.up_id.clone(),
                 collection_type: task.collection_type.clone(),
                 collection_aggregate_enabled: task.collection_aggregate_enabled,
+                filter_option: task.filter_option.clone(),
                 media_id: task.media_id.clone(),
                 ep_id: task.ep_id.clone(),
                 download_all_seasons: task.download_all_seasons,

--- a/crates/bili_sync/src/workflow.rs
+++ b/crates/bili_sync/src/workflow.rs
@@ -2590,6 +2590,18 @@ pub async fn download_unprocessed_videos(
     }
     video_source.log_download_video_start();
     let current_config = crate::config::reload_config();
+    let source_filter_option = video_source
+        .filter_option()
+        .map(|value| serde_json::from_value::<FilterOption>(value.clone()))
+        .transpose()
+        .with_context(|| {
+            format!(
+                "解析{}「{}」自定义流过滤设置失败",
+                video_source.source_type_display(),
+                video_source.source_name_display()
+            )
+        })?;
+    let effective_filter_option = source_filter_option.unwrap_or_else(|| current_config.filter_option.clone());
     let mut unhandled_videos_pages = filter_unhandled_video_pages(video_source.filter_expr(), connection).await?;
     let original_unhandled_video_count = unhandled_videos_pages.len();
     let original_unhandled_page_count = unhandled_videos_pages
@@ -2705,6 +2717,7 @@ pub async fn download_unprocessed_videos(
                 should_download_upper,
                 large_source_policy.page_concurrency,
                 &chapter_episode_plans,
+                &effective_filter_option,
                 token.clone(),
             )
         })
@@ -3365,6 +3378,18 @@ pub async fn retry_failed_videos_once(
         return Ok(());
     }
     let current_config = crate::config::reload_config();
+    let source_filter_option = video_source
+        .filter_option()
+        .map(|value| serde_json::from_value::<FilterOption>(value.clone()))
+        .transpose()
+        .with_context(|| {
+            format!(
+                "解析{}「{}」自定义流过滤设置失败",
+                video_source.source_type_display(),
+                video_source.source_name_display()
+            )
+        })?;
+    let effective_filter_option = source_filter_option.unwrap_or_else(|| current_config.filter_option.clone());
     let mut failed_videos_pages = get_failed_videos_in_current_cycle(video_source.filter_expr(), connection).await?;
 
     if failed_videos_pages.is_empty() {
@@ -3459,6 +3484,7 @@ pub async fn retry_failed_videos_once(
                 should_download_upper,
                 large_source_policy.page_concurrency,
                 &chapter_episode_plans,
+                &effective_filter_option,
                 token.clone(),
             )
         })
@@ -3560,6 +3586,7 @@ struct DownloadPageArgs<'a> {
     base_path: &'a Path,
     page_concurrency: usize,
     chapter_episode_plans: &'a HashMap<i32, ChapterEpisodePlan>,
+    filter_option: &'a FilterOption,
     inline_total_file_size_bytes: Arc<TokioMutex<Option<i64>>>,
     inline_chapters_split: Arc<TokioMutex<bool>>,
 }
@@ -3584,6 +3611,7 @@ async fn download_video_pages(
     should_download_upper: bool,
     page_concurrency: usize,
     chapter_episode_plans: &HashMap<i32, ChapterEpisodePlan>,
+    filter_option: &FilterOption,
     token: CancellationToken,
 ) -> Result<video::ActiveModel> {
     let _permit = tokio::select! {
@@ -5559,6 +5587,7 @@ async fn download_video_pages(
                 base_path: &base_path,
                 page_concurrency,
                 chapter_episode_plans,
+                filter_option,
                 inline_total_file_size_bytes: inline_total_file_size_bytes.clone(),
                 inline_chapters_split: inline_chapters_split.clone(),
             },
@@ -6220,6 +6249,7 @@ async fn dispatch_download_page(args: DownloadPageArgs<'_>, token: CancellationT
             let connection = args.connection;
             let downloader = args.downloader;
             let base_path = args.base_path;
+            let filter_option = args.filter_option;
             let chapter_episode_plan = args.chapter_episode_plans.get(&page_model.id).cloned();
             async move {
                 let result = download_page(
@@ -6232,6 +6262,7 @@ async fn dispatch_download_page(args: DownloadPageArgs<'_>, token: CancellationT
                     downloader,
                     base_path,
                     chapter_episode_plan,
+                    filter_option,
                     token_clone,
                 )
                 .await;
@@ -6557,6 +6588,7 @@ async fn download_page(
     downloader: &UnifiedDownloader,
     base_path: &Path,
     chapter_episode_plan: Option<ChapterEpisodePlan>,
+    filter_option: &FilterOption,
     token: CancellationToken,
 ) -> Result<PageDownloadOutcome> {
     let _permit = tokio::select! {
@@ -7003,6 +7035,7 @@ async fn download_page(
         &page_info,
         &video_path,
         audio_only,
+        filter_option,
         token.clone(),
     ));
     let res_3_fut = Box::pin(generate_page_nfo(
@@ -8597,6 +8630,7 @@ async fn fetch_page_video(
     page_info: &PageInfo,
     page_path: &Path,
     audio_only: bool,
+    filter_option: &FilterOption,
     token: CancellationToken,
 ) -> Result<PageVideoFetchResult> {
     if !should_run {
@@ -8628,7 +8662,6 @@ async fn fetch_page_video(
 
     // 获取用户配置的筛选选项（用于按画质范围请求播放地址，避免拿到高画质单流后被过滤导致无视频流）
     let config = crate::config::reload_config();
-    let filter_option = &config.filter_option;
     let (max_qn, min_qn) = crate::bilibili::effective_playurl_qn_range(
         filter_option.video_max_quality as u32,
         filter_option.video_min_quality as u32,

--- a/crates/bili_sync_entity/src/entities/collection.rs
+++ b/crates/bili_sync_entity/src/entities/collection.rs
@@ -17,6 +17,7 @@ pub struct Model {
     pub enabled: bool,
     pub scan_deleted_videos: bool,
     pub scan_deleted_videos_once: bool,
+    pub filter_option: Option<serde_json::Value>,
     pub cover: Option<String>,
     pub keyword_filters: Option<String>,
     pub keyword_filter_mode: Option<String>,

--- a/crates/bili_sync_entity/src/entities/favorite.rs
+++ b/crates/bili_sync_entity/src/entities/favorite.rs
@@ -16,6 +16,7 @@ pub struct Model {
     pub enabled: bool,
     pub scan_deleted_videos: bool,
     pub scan_deleted_videos_once: bool,
+    pub filter_option: Option<serde_json::Value>,
     pub keyword_filters: Option<String>,
     pub keyword_filter_mode: Option<String>,
     pub blacklist_keywords: Option<String>,

--- a/crates/bili_sync_entity/src/entities/submission.rs
+++ b/crates/bili_sync_entity/src/entities/submission.rs
@@ -15,6 +15,7 @@ pub struct Model {
     pub enabled: bool,
     pub scan_deleted_videos: bool,
     pub scan_deleted_videos_once: bool,
+    pub filter_option: Option<serde_json::Value>,
     pub selected_videos: Option<String>,
     pub keyword_filters: Option<String>,
     pub keyword_filter_mode: Option<String>,

--- a/crates/bili_sync_entity/src/entities/video_source.rs
+++ b/crates/bili_sync_entity/src/entities/video_source.rs
@@ -32,6 +32,7 @@ pub struct Model {
     pub enabled: bool,
     pub scan_deleted_videos: bool,
     pub scan_deleted_videos_once: bool,
+    pub filter_option: Option<serde_json::Value>,
     pub cached_episodes: Option<String>,
     pub cache_updated_at: Option<String>,
     pub keyword_filters: Option<String>,

--- a/crates/bili_sync_entity/src/entities/watch_later.rs
+++ b/crates/bili_sync_entity/src/entities/watch_later.rs
@@ -13,6 +13,7 @@ pub struct Model {
     pub enabled: bool,
     pub scan_deleted_videos: bool,
     pub scan_deleted_videos_once: bool,
+    pub filter_option: Option<serde_json::Value>,
     pub keyword_filters: Option<String>,
     pub keyword_filter_mode: Option<String>,
     pub blacklist_keywords: Option<String>,

--- a/crates/bili_sync_migration/src/lib.rs
+++ b/crates/bili_sync_migration/src/lib.rs
@@ -67,6 +67,7 @@ mod m20260330_000001_add_video_file_size_fields;
 mod m20260414_000001_add_danmaku_sync_fields;
 mod m20260415_000001_add_split_chapters_to_sources;
 mod m20260704_000001_add_ai_subtitle_settings;
+mod m20260718_000001_add_source_filter_option;
 
 pub struct Migrator;
 
@@ -141,6 +142,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260414_000001_add_danmaku_sync_fields::Migration),
             Box::new(m20260415_000001_add_split_chapters_to_sources::Migration),
             Box::new(m20260704_000001_add_ai_subtitle_settings::Migration),
+            Box::new(m20260718_000001_add_source_filter_option::Migration),
         ]
     }
 }

--- a/crates/bili_sync_migration/src/m20260718_000001_add_source_filter_option.rs
+++ b/crates/bili_sync_migration/src/m20260718_000001_add_source_filter_option.rs
@@ -1,0 +1,57 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for table in VideoSourceTable::tables() {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(table)
+                        .add_column(ColumnDef::new(VideoSourceTable::FilterOption).json().null())
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for table in VideoSourceTable::tables() {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(table)
+                        .drop_column(VideoSourceTable::FilterOption)
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum VideoSourceTable {
+    Collection,
+    Favorite,
+    Submission,
+    WatchLater,
+    VideoSource,
+    FilterOption,
+}
+
+impl VideoSourceTable {
+    fn tables() -> [Self; 5] {
+        [
+            Self::Collection,
+            Self::Favorite,
+            Self::Submission,
+            Self::WatchLater,
+            Self::VideoSource,
+        ]
+    }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
 	ApiResponse,
 	VideoSourcesResponse,
+	FilterOption,
 	VideosRequest,
 	VideosResponse,
 	VideoResponse,
@@ -409,6 +410,7 @@ class ApiClient {
 			ai_rename_enable_collection?: boolean;
 			ai_rename_enable_bangumi?: boolean;
 			ai_rename_rename_parent_dir?: boolean;
+			filter_option?: FilterOption | null;
 		}
 	): Promise<
 		ApiResponse<{
@@ -433,6 +435,7 @@ class ApiClient {
 			use_dynamic_api: boolean;
 			collection_aggregate_enabled: boolean;
 			collection_aggregate_season_number?: number;
+			filter_option?: FilterOption | null;
 			message: string;
 		}>
 	> {
@@ -458,6 +461,7 @@ class ApiClient {
 			use_dynamic_api: boolean;
 			collection_aggregate_enabled: boolean;
 			collection_aggregate_season_number?: number;
+			filter_option?: FilterOption | null;
 			message: string;
 		}>(`/video-sources/${sourceType}/${id}/download-options`, options);
 	}
@@ -1222,6 +1226,7 @@ export const api = {
 			ai_rename_enable_collection?: boolean;
 			ai_rename_enable_bangumi?: boolean;
 			ai_rename_rename_parent_dir?: boolean;
+			filter_option?: FilterOption | null;
 		}
 	) => apiClient.updateVideoSourceDownloadOptions(sourceType, id, options),
 

--- a/web/src/lib/components/filter-option-editor.svelte
+++ b/web/src/lib/components/filter-option-editor.svelte
@@ -1,0 +1,246 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Label } from '$lib/components/ui/label';
+	import { createEventDispatcher } from 'svelte';
+	import type { AudioQuality, FilterOption, VideoCodec, VideoQuality } from '$lib/types';
+
+	export let value: FilterOption;
+	export let disabled = false;
+
+	const dispatch = createEventDispatcher<{ change: FilterOption }>();
+
+	const videoQualityOptions: { value: VideoQuality; label: string }[] = [
+		{ value: 'Quality8k', label: '8K超高清' },
+		{ value: 'QualityDolby', label: '杜比视界' },
+		{ value: 'QualityHdr', label: 'HDR真彩' },
+		{ value: 'Quality4k', label: '4K超高清' },
+		{ value: 'Quality1080p60', label: '1080P 60fps' },
+		{ value: 'Quality1080pPLUS', label: '1080P+高码率' },
+		{ value: 'Quality1080p', label: '1080P高清' },
+		{ value: 'Quality720p', label: '720P高清' },
+		{ value: 'Quality480p', label: '480P清晰' },
+		{ value: 'Quality360p', label: '360P流畅' }
+	];
+
+	const audioQualityOptions: { value: AudioQuality; label: string }[] = [
+		{ value: 'QualityHiRES', label: 'Hi-Res无损' },
+		{ value: 'Quality192k', label: '192K高品质' },
+		{ value: 'QualityDolby', label: '杜比全景声' },
+		{ value: 'QualityDolbyBangumi', label: '杜比全景声（番剧）' },
+		{ value: 'Quality132k', label: '132K标准' },
+		{ value: 'Quality64k', label: '64K省流' }
+	];
+
+	const codecOptions: { value: VideoCodec; label: string }[] = [
+		{ value: 'AVC', label: 'AVC/H.264' },
+		{ value: 'HEV', label: 'HEVC/H.265' },
+		{ value: 'AV1', label: 'AV1' }
+	];
+
+	function updateField<K extends keyof FilterOption>(key: K, nextValue: FilterOption[K]) {
+		dispatch('change', { ...value, [key]: nextValue });
+	}
+
+	function updateBoolean(key: 'no_dolby_video' | 'no_dolby_audio' | 'no_hdr' | 'no_hires', checked: boolean) {
+		updateField(key, checked);
+	}
+
+	function moveCodec(index: number, delta: number) {
+		const nextIndex = index + delta;
+		if (nextIndex < 0 || nextIndex >= value.codecs.length) return;
+
+		const nextCodecs = [...value.codecs];
+		const [codec] = nextCodecs.splice(index, 1);
+		nextCodecs.splice(nextIndex, 0, codec);
+		updateField('codecs', nextCodecs);
+	}
+
+	function removeCodec(index: number) {
+		updateField(
+			'codecs',
+			value.codecs.filter((_, currentIndex) => currentIndex !== index)
+		);
+	}
+
+	function handleAddCodec(event: Event) {
+		const select = event.currentTarget as HTMLSelectElement;
+		const codec = select.value as VideoCodec;
+		if (codec && !value.codecs.includes(codec)) {
+			updateField('codecs', [...value.codecs, codec]);
+		}
+		select.value = '';
+	}
+</script>
+
+<div class="space-y-5">
+	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+		<div class="space-y-2">
+			<Label for="source-video-max-quality">视频最高质量</Label>
+			<select
+				id="source-video-max-quality"
+				value={value.video_max_quality}
+				{disabled}
+				onchange={(event) =>
+					updateField('video_max_quality', (event.currentTarget as HTMLSelectElement).value as VideoQuality)}
+				class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{#each videoQualityOptions as option (option.value)}
+					<option value={option.value}>{option.label}</option>
+				{/each}
+			</select>
+		</div>
+
+		<div class="space-y-2">
+			<Label for="source-video-min-quality">视频最低质量</Label>
+			<select
+				id="source-video-min-quality"
+				value={value.video_min_quality}
+				{disabled}
+				onchange={(event) =>
+					updateField('video_min_quality', (event.currentTarget as HTMLSelectElement).value as VideoQuality)}
+				class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{#each videoQualityOptions as option (option.value)}
+					<option value={option.value}>{option.label}</option>
+				{/each}
+			</select>
+		</div>
+
+		<div class="space-y-2">
+			<Label for="source-audio-max-quality">音频最高质量</Label>
+			<select
+				id="source-audio-max-quality"
+				value={value.audio_max_quality}
+				{disabled}
+				onchange={(event) =>
+					updateField('audio_max_quality', (event.currentTarget as HTMLSelectElement).value as AudioQuality)}
+				class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{#each audioQualityOptions as option (option.value)}
+					<option value={option.value}>{option.label}</option>
+				{/each}
+			</select>
+		</div>
+
+		<div class="space-y-2">
+			<Label for="source-audio-min-quality">音频最低质量</Label>
+			<select
+				id="source-audio-min-quality"
+				value={value.audio_min_quality}
+				{disabled}
+				onchange={(event) =>
+					updateField('audio_min_quality', (event.currentTarget as HTMLSelectElement).value as AudioQuality)}
+				class="border-input bg-background ring-offset-background focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{#each audioQualityOptions as option (option.value)}
+					<option value={option.value}>{option.label}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+
+	<div class="space-y-2">
+		<Label>编解码器优先级</Label>
+		<p class="text-muted-foreground text-xs">越靠前优先级越高；至少保留一个编码，避免没有可用视频流。</p>
+		<div class="space-y-2">
+			{#each value.codecs as codec, index (codec)}
+				<div class="flex items-center gap-2 rounded-lg border bg-gray-50 p-2 dark:bg-gray-900">
+					<span
+						class="bg-primary text-primary-foreground flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium"
+					>
+						{index + 1}
+					</span>
+					<span class="flex-1 text-sm font-medium">
+						{codecOptions.find((option) => option.value === codec)?.label ?? codec}
+					</span>
+					<Button
+						type="button"
+						size="sm"
+						variant="outline"
+						disabled={disabled || index === 0}
+						onclick={() => moveCodec(index, -1)}
+					>
+						上移
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						variant="outline"
+						disabled={disabled || index === value.codecs.length - 1}
+						onclick={() => moveCodec(index, 1)}
+					>
+						下移
+					</Button>
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						disabled={disabled || value.codecs.length <= 1}
+						onclick={() => removeCodec(index)}
+					>
+						移除
+					</Button>
+				</div>
+			{/each}
+
+			{#if value.codecs.length < codecOptions.length}
+				<select
+					value=""
+					{disabled}
+					onchange={handleAddCodec}
+					class="border-input bg-background h-9 w-full rounded-md border px-3 py-2 text-sm disabled:cursor-not-allowed disabled:opacity-50"
+				>
+					<option value="" disabled>添加编解码器...</option>
+					{#each codecOptions as option (option.value)}
+						{#if !value.codecs.includes(option.value)}
+							<option value={option.value}>{option.label}</option>
+						{/if}
+					{/each}
+				</select>
+			{/if}
+		</div>
+	</div>
+
+	<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+		<label class="flex items-center gap-2 text-sm">
+			<input
+				type="checkbox"
+				checked={value.no_dolby_video}
+				{disabled}
+				onchange={(event) => updateBoolean('no_dolby_video', (event.currentTarget as HTMLInputElement).checked)}
+				class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+			/>
+			禁用杜比视界
+		</label>
+		<label class="flex items-center gap-2 text-sm">
+			<input
+				type="checkbox"
+				checked={value.no_dolby_audio}
+				{disabled}
+				onchange={(event) => updateBoolean('no_dolby_audio', (event.currentTarget as HTMLInputElement).checked)}
+				class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+			/>
+			禁用杜比全景声
+		</label>
+		<label class="flex items-center gap-2 text-sm">
+			<input
+				type="checkbox"
+				checked={value.no_hdr}
+				{disabled}
+				onchange={(event) => updateBoolean('no_hdr', (event.currentTarget as HTMLInputElement).checked)}
+				class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+			/>
+			禁用HDR
+		</label>
+		<label class="flex items-center gap-2 text-sm">
+			<input
+				type="checkbox"
+				checked={value.no_hires}
+				{disabled}
+				onchange={(event) => updateBoolean('no_hires', (event.currentTarget as HTMLInputElement).checked)}
+				class="text-primary focus:ring-primary h-4 w-4 rounded border-gray-300"
+			/>
+			禁用Hi-Res音频
+		</label>
+	</div>
+</div>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -7,13 +7,7 @@ export interface ApiResponse<T> {
 
 // 排序字段枚举
 export type SortBy =
-	| 'id'
-	| 'name'
-	| 'upper_name'
-	| 'created_at'
-	| 'pubtime'
-	| 'is_charge_video'
-	| 'file_size';
+	'id' | 'name' | 'upper_name' | 'created_at' | 'pubtime' | 'is_charge_video' | 'file_size';
 
 // 排序顺序枚举
 export type SortOrder = 'asc' | 'desc';
@@ -38,6 +32,41 @@ export interface VideosRequest {
 // 关键词过滤模式类型
 export type KeywordFilterMode = 'blacklist' | 'whitelist';
 
+// 视频/音频流过滤配置
+export type VideoQuality =
+	| 'Quality360p'
+	| 'Quality480p'
+	| 'Quality720p'
+	| 'Quality1080p'
+	| 'Quality1080pPLUS'
+	| 'Quality1080p60'
+	| 'Quality4k'
+	| 'QualityHdr'
+	| 'QualityDolby'
+	| 'Quality8k';
+
+export type AudioQuality =
+	| 'Quality64k'
+	| 'Quality132k'
+	| 'QualityDolby'
+	| 'QualityHiRES'
+	| 'QualityDolbyBangumi'
+	| 'Quality192k';
+
+export type VideoCodec = 'AVC' | 'HEV' | 'AV1';
+
+export interface FilterOption {
+	video_max_quality: VideoQuality;
+	video_min_quality: VideoQuality;
+	audio_max_quality: AudioQuality;
+	audio_min_quality: AudioQuality;
+	codecs: VideoCodec[];
+	no_dolby_video: boolean;
+	no_dolby_audio: boolean;
+	no_hdr: boolean;
+	no_hires: boolean;
+}
+
 // 视频来源类型
 export interface VideoSource {
 	id: number;
@@ -60,6 +89,7 @@ export interface VideoSource {
 	selected_seasons?: string[];
 	selected_videos?: string | null; // 投稿源：选中视频（JSON字符串）
 	use_dynamic_api?: boolean; // 投稿源：是否使用动态API
+	filter_option?: FilterOption | null; // 视频源级流过滤配置，空表示继承全局
 	// 新的双列表模式关键词过滤
 	blacklist_keywords?: string[]; // 黑名单关键词列表（匹配的视频将被排除）
 	whitelist_keywords?: string[]; // 白名单关键词列表（只下载匹配的视频）
@@ -247,6 +277,7 @@ export interface AddVideoSourceRequest {
 	merge_to_source_id?: number;
 	keyword_filters?: string[]; // 关键词过滤器列表（支持正则表达式）
 	keyword_filter_mode?: KeywordFilterMode; // 关键词过滤模式: "blacklist"（排除匹配）或 "whitelist"（只下载匹配）
+	filter_option?: FilterOption | null; // 视频源级流过滤配置，空表示继承全局
 	// 下载选项
 	audio_only?: boolean; // 仅下载音频（输出m4a格式）
 	audio_only_m4a_only?: boolean; // 仅音频时只保留m4a（不下载封面/nfo/弹幕/字幕）

--- a/web/src/routes/add-source/+page.svelte
+++ b/web/src/routes/add-source/+page.svelte
@@ -3,6 +3,7 @@
 	import api from '$lib/api';
 	import BatchCheckbox from '$lib/components/batch-checkbox.svelte';
 	import BiliImage from '$lib/components/bili-image.svelte';
+	import FilterOptionEditor from '$lib/components/filter-option-editor.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import EmptyState from '$lib/components/empty-state.svelte';
 	import SectionHeader from '$lib/components/section-header.svelte';
@@ -29,7 +30,11 @@
 		ConfigResponse,
 		UserCollectionInfo,
 		AddVideoSourceRequest,
-		KeywordFilterMode
+		KeywordFilterMode,
+		FilterOption,
+		VideoQuality,
+		AudioQuality,
+		VideoCodec
 	} from '$lib/types';
 	import {
 		Search,
@@ -37,7 +42,8 @@
 		Plus as PlusIcon,
 		Filter as FilterIcon,
 		Info as InfoIcon,
-		Languages as LanguagesIcon
+		Languages as LanguagesIcon,
+		SlidersHorizontal as SlidersHorizontalIcon
 	} from '@lucide/svelte';
 	import { onDestroy, onMount } from 'svelte';
 	import { toast } from 'svelte-sonner';
@@ -55,6 +61,38 @@
 		{ value: 'ja-JP', label: '日语' },
 		{ value: 'ko-KR', label: '韩语' }
 	];
+	const VALID_VIDEO_QUALITIES = new Set<VideoQuality>([
+		'Quality360p',
+		'Quality480p',
+		'Quality720p',
+		'Quality1080p',
+		'Quality1080pPLUS',
+		'Quality1080p60',
+		'Quality4k',
+		'QualityHdr',
+		'QualityDolby',
+		'Quality8k'
+	]);
+	const VALID_AUDIO_QUALITIES = new Set<AudioQuality>([
+		'Quality64k',
+		'Quality132k',
+		'QualityDolby',
+		'QualityHiRES',
+		'QualityDolbyBangumi',
+		'Quality192k'
+	]);
+	const VALID_VIDEO_CODECS = new Set<VideoCodec>(['AVC', 'HEV', 'AV1']);
+	const DEFAULT_FILTER_OPTION: FilterOption = {
+		video_max_quality: 'Quality8k',
+		video_min_quality: 'Quality360p',
+		audio_max_quality: 'QualityHiRES',
+		audio_min_quality: 'Quality64k',
+		codecs: ['AVC', 'HEV', 'AV1'],
+		no_dolby_video: false,
+		no_dolby_audio: false,
+		no_hdr: false,
+		no_hires: false
+	};
 
 	let sourceType: VideoCategory = 'collection';
 	let lastSourceType: VideoCategory = sourceType; // 记录上一次的源类型，用于检测切换
@@ -82,6 +120,15 @@
 	let downloadSubtitle = true; // 下载字幕（默认开启）
 	let downloadAiSubtitle = true; // 下载 B 站 AI 字幕（默认开启）
 	let aiSubtitleLanguage = DEFAULT_AI_SUBTITLE_LANGUAGE; // AI 字幕优先语言
+	let filterOptionInheritGlobal = true; // 是否继承全局流过滤/码率设置
+	let filterOptionDraft: FilterOption = {
+		...DEFAULT_FILTER_OPTION,
+		codecs: [...DEFAULT_FILTER_OPTION.codecs]
+	};
+	let globalFilterOptionDefault: FilterOption = {
+		...DEFAULT_FILTER_OPTION,
+		codecs: [...DEFAULT_FILTER_OPTION.codecs]
+	};
 	let useDynamicApi = false; // 投稿源：使用动态API
 	let aiRename = false; // AI重命名（默认关闭）
 	let aiRenameVideoPrompt = ''; // AI重命名视频提示词
@@ -337,6 +384,58 @@
 		collectionQuickSubscribePathTemplate = config.collection_quick_subscribe_path || '';
 		submissionQuickSubscribePathTemplate = config.submission_quick_subscribe_path || '';
 		bangumiQuickSubscribePathTemplate = config.bangumi_quick_subscribe_path || '';
+		globalFilterOptionDefault = filterOptionFromConfig(config);
+		if (filterOptionInheritGlobal) {
+			filterOptionDraft = cloneFilterOption(globalFilterOptionDefault);
+		}
+	}
+
+	function cloneFilterOption(option: FilterOption): FilterOption {
+		return {
+			...option,
+			codecs: [...option.codecs]
+		};
+	}
+
+	function normalizeVideoQuality(value: string | undefined, fallback: VideoQuality): VideoQuality {
+		return value && VALID_VIDEO_QUALITIES.has(value as VideoQuality) ? (value as VideoQuality) : fallback;
+	}
+
+	function normalizeAudioQuality(value: string | undefined, fallback: AudioQuality): AudioQuality {
+		return value && VALID_AUDIO_QUALITIES.has(value as AudioQuality) ? (value as AudioQuality) : fallback;
+	}
+
+	function normalizeVideoCodecs(values: string[] | undefined): VideoCodec[] {
+		const codecs = values?.filter((codec): codec is VideoCodec =>
+			VALID_VIDEO_CODECS.has(codec as VideoCodec)
+		);
+		return codecs && codecs.length > 0 ? codecs : [...DEFAULT_FILTER_OPTION.codecs];
+	}
+
+	function filterOptionFromConfig(config: ConfigResponse): FilterOption {
+		return {
+			video_max_quality: normalizeVideoQuality(
+				config.video_max_quality,
+				DEFAULT_FILTER_OPTION.video_max_quality
+			),
+			video_min_quality: normalizeVideoQuality(
+				config.video_min_quality,
+				DEFAULT_FILTER_OPTION.video_min_quality
+			),
+			audio_max_quality: normalizeAudioQuality(
+				config.audio_max_quality,
+				DEFAULT_FILTER_OPTION.audio_max_quality
+			),
+			audio_min_quality: normalizeAudioQuality(
+				config.audio_min_quality,
+				DEFAULT_FILTER_OPTION.audio_min_quality
+			),
+			codecs: normalizeVideoCodecs(config.codecs),
+			no_dolby_video: config.no_dolby_video ?? DEFAULT_FILTER_OPTION.no_dolby_video,
+			no_dolby_audio: config.no_dolby_audio ?? DEFAULT_FILTER_OPTION.no_dolby_audio,
+			no_hdr: config.no_hdr ?? DEFAULT_FILTER_OPTION.no_hdr,
+			no_hires: config.no_hires ?? DEFAULT_FILTER_OPTION.no_hires
+		};
 	}
 
 	// 订阅的合集相关
@@ -814,6 +913,11 @@
 			return;
 		}
 
+		if (!filterOptionInheritGlobal && filterOptionDraft.codecs.length === 0) {
+			toast.error('码率设置无效', { description: '至少保留一个编解码器' });
+			return;
+		}
+
 		// 番剧特殊验证
 		if (sourceType === 'bangumi') {
 			// 如果不是下载全部季度，且没有选择任何季度，且不是单季度情况，则提示错误
@@ -843,6 +947,7 @@
 			ai_rename: aiRename,
 			ai_rename_video_prompt: aiRenameVideoPrompt.trim() || undefined,
 			ai_rename_audio_prompt: aiRenameAudioPrompt.trim() || undefined,
+			filter_option: filterOptionInheritGlobal ? undefined : cloneFilterOption(filterOptionDraft),
 			// AI重命名高级选项（仅当开启高级选项时传递）
 			ai_rename_enable_multi_page: showAiRenameAdvanced ? aiRenameEnableMultiPage : undefined,
 			ai_rename_enable_collection: showAiRenameAdvanced ? aiRenameEnableCollection : undefined,
@@ -999,6 +1104,8 @@
 			downloadSubtitle = true;
 			downloadAiSubtitle = true;
 			aiSubtitleLanguage = DEFAULT_AI_SUBTITLE_LANGUAGE;
+			filterOptionInheritGlobal = true;
+			filterOptionDraft = cloneFilterOption(globalFilterOptionDefault);
 			useDynamicApi = false;
 			aiRename = false;
 			aiRenameVideoPrompt = '';
@@ -2293,6 +2400,10 @@
 			});
 			return;
 		}
+		if (!filterOptionInheritGlobal && filterOptionDraft.codecs.length === 0) {
+			toast.error('码率设置无效', { description: '至少保留一个编解码器' });
+			return;
+		}
 		batchProgress = { current: 0, total: batchSelectedItems.size };
 
 		const selectedItems = Array.from(batchSelectedItems.entries());
@@ -2325,6 +2436,9 @@
 						ai_rename: aiRename,
 						ai_rename_video_prompt: aiRenameVideoPrompt.trim() || undefined,
 						ai_rename_audio_prompt: aiRenameAudioPrompt.trim() || undefined,
+						filter_option: filterOptionInheritGlobal
+							? undefined
+							: cloneFilterOption(filterOptionDraft),
 						ai_rename_enable_multi_page: showAiRenameAdvanced
 							? aiRenameEnableMultiPage
 							: undefined,
@@ -3497,6 +3611,51 @@
 									</div>
 								{/if}
 							</div>
+						</div>
+
+						<!-- 源级码率/流过滤设置 -->
+						<div class="space-y-3">
+							<div
+								class="flex items-center justify-between rounded-md border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/30"
+							>
+								<div class="flex items-center gap-2 pr-3">
+									<SlidersHorizontalIcon class="h-4 w-4 text-blue-600 dark:text-blue-400" />
+									<div>
+										<span class="text-sm font-medium text-blue-800 dark:text-blue-200">
+											源级码率/流过滤
+										</span>
+										<p class="text-[10px] text-blue-600 dark:text-blue-300">
+											可为本次添加的专集、UP、收藏夹、稍后观看或番剧单独设置质量筛选规则
+										</p>
+									</div>
+								</div>
+								<div class="flex items-center gap-2">
+									<span class="text-xs text-blue-700 dark:text-blue-300">继承全局</span>
+									<label class="relative inline-flex cursor-pointer items-center">
+										<input
+											type="checkbox"
+											bind:checked={filterOptionInheritGlobal}
+											class="peer sr-only"
+										/>
+										<div
+											class="peer h-5 w-9 rounded-full bg-gray-300 peer-checked:bg-blue-600 peer-focus:ring-2 peer-focus:ring-blue-500 peer-focus:outline-none after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white dark:bg-gray-600 dark:peer-checked:bg-blue-500"
+										></div>
+									</label>
+								</div>
+							</div>
+
+							{#if filterOptionInheritGlobal}
+								<p class="text-muted-foreground rounded-md border border-dashed px-3 py-2 text-xs">
+									当前新源会继承设置页的全局视频/音频质量配置；关闭“继承全局”后可为该同步源单独限码率。
+								</p>
+							{:else}
+								<div class="rounded-md border border-blue-200 bg-white p-4 dark:border-blue-800 dark:bg-gray-900">
+									<FilterOptionEditor
+										value={filterOptionDraft}
+										on:change={(event) => (filterOptionDraft = event.detail)}
+									/>
+								</div>
+							{/if}
 						</div>
 
 						<!-- 关键词过滤器（可折叠，双列表模式） -->
@@ -5158,7 +5317,7 @@
 		transition:fade
 	>
 		<div
-			class="bg-card mx-4 w-full max-w-md rounded-lg border shadow-lg"
+			class="bg-card mx-4 max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-lg border shadow-lg"
 			transition:fly={{ y: -50 }}
 		>
 			<div class="border-b p-4">
@@ -5208,6 +5367,47 @@
 								>{'{{name}}'}</code
 							> 变量。
 						</p>
+					{/if}
+				</div>
+
+				<div class="space-y-3">
+					<div
+						class="flex items-center justify-between rounded-md border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-800 dark:bg-blue-950/30"
+					>
+						<div class="flex items-center gap-2 pr-3">
+							<SlidersHorizontalIcon class="h-4 w-4 text-blue-600 dark:text-blue-400" />
+							<div>
+								<div class="text-sm font-medium text-blue-800 dark:text-blue-200">
+									批量源级码率/流过滤
+								</div>
+								<p class="mt-1 text-xs text-blue-600 dark:text-blue-300">
+									当前设置会应用到本次批量添加的每个视频源。
+								</p>
+							</div>
+						</div>
+						<div class="flex items-center gap-2">
+							<span class="text-xs text-blue-700 dark:text-blue-300">继承全局</span>
+							<label class="relative inline-flex cursor-pointer items-center">
+								<input
+									type="checkbox"
+									bind:checked={filterOptionInheritGlobal}
+									class="peer sr-only"
+								/>
+								<div
+									class="peer h-5 w-9 rounded-full bg-gray-300 peer-checked:bg-blue-600 peer-focus:ring-2 peer-focus:ring-blue-500 peer-focus:outline-none after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white dark:bg-gray-600 dark:peer-checked:bg-blue-500"
+								></div>
+							</label>
+						</div>
+					</div>
+
+					{#if !filterOptionInheritGlobal}
+						<div class="rounded-md border border-blue-200 bg-white p-4 dark:border-blue-800 dark:bg-gray-900">
+							<FilterOptionEditor
+								value={filterOptionDraft}
+								disabled={batchAdding}
+								on:change={(event) => (filterOptionDraft = event.detail)}
+							/>
+						</div>
 					{/if}
 				</div>
 

--- a/web/src/routes/video-sources/+page.svelte
+++ b/web/src/routes/video-sources/+page.svelte
@@ -19,12 +19,21 @@
 	import SubmissionSelectionDialog from '$lib/components/submission-selection-dialog.svelte';
 	import KeywordFilterDialog from '$lib/components/keyword-filter-dialog.svelte';
 	import AiPromptDialog from '$lib/components/ai-prompt-dialog.svelte';
+	import FilterOptionEditor from '$lib/components/filter-option-editor.svelte';
 	import SectionHeader from '$lib/components/section-header.svelte';
 	import Loading from '$lib/components/ui/Loading.svelte';
 	import SelectAllButton from '$lib/components/select-all-button.svelte';
 	import EmptyState from '$lib/components/empty-state.svelte';
 	import AiRenameHistoryDialog from '$lib/components/ai-rename-history-dialog.svelte';
-	import type { VideoSource, VideoSourcesResponse } from '$lib/types';
+	import type {
+		AudioQuality,
+		ConfigResponse,
+		FilterOption,
+		VideoCodec,
+		VideoQuality,
+		VideoSource,
+		VideoSourcesResponse
+	} from '$lib/types';
 
 	// 图标导入
 	import PlusIcon from '@lucide/svelte/icons/plus';
@@ -47,6 +56,7 @@
 	import BatteryChargingIcon from '@lucide/svelte/icons/battery-charging';
 	import SparklesIcon from '@lucide/svelte/icons/sparkles';
 	import HistoryIcon from '@lucide/svelte/icons/history';
+	import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { formatCompactTimestampOrFallback } from '$lib/utils/timezone';
@@ -61,6 +71,38 @@
 		{ value: 'ja-JP', label: '日语' },
 		{ value: 'ko-KR', label: '韩语' }
 	];
+	const VALID_VIDEO_QUALITIES = new Set<VideoQuality>([
+		'Quality360p',
+		'Quality480p',
+		'Quality720p',
+		'Quality1080p',
+		'Quality1080pPLUS',
+		'Quality1080p60',
+		'Quality4k',
+		'QualityHdr',
+		'QualityDolby',
+		'Quality8k'
+	]);
+	const VALID_AUDIO_QUALITIES = new Set<AudioQuality>([
+		'Quality64k',
+		'Quality132k',
+		'QualityDolby',
+		'QualityHiRES',
+		'QualityDolbyBangumi',
+		'Quality192k'
+	]);
+	const VALID_VIDEO_CODECS = new Set<VideoCodec>(['AVC', 'HEV', 'AV1']);
+	const DEFAULT_FILTER_OPTION: FilterOption = {
+		video_max_quality: 'Quality8k',
+		video_min_quality: 'Quality360p',
+		audio_max_quality: 'QualityHiRES',
+		audio_min_quality: 'Quality64k',
+		codecs: ['AVC', 'HEV', 'AV1'],
+		no_dolby_video: false,
+		no_dolby_audio: false,
+		no_hdr: false,
+		no_hires: false
+	};
 
 	let loading = false;
 	let bulkUpdating = false;
@@ -116,6 +158,17 @@
 		id: 0,
 		name: ''
 	};
+
+	// 源级流过滤/码率设置对话框状态
+	let showFilterOptionDialog = false;
+	let filterOptionInfo = {
+		type: '',
+		id: 0,
+		name: ''
+	};
+	let filterOptionDraft: FilterOption = { ...DEFAULT_FILTER_OPTION, codecs: [...DEFAULT_FILTER_OPTION.codecs] };
+	let filterOptionInheritGlobal = true;
+	let filterOptionSaving = false;
 
 	// AI提示词对话框状态
 	let showAiPromptDialog = false;
@@ -336,6 +389,54 @@
 	function getAiSubtitleLanguageLabel(language?: string | null): string {
 		const normalized = normalizeAiSubtitleLanguage(language);
 		return AI_SUBTITLE_LANGUAGE_OPTIONS.find((option) => option.value === normalized)?.label ?? normalized;
+	}
+
+	function cloneFilterOption(option: FilterOption): FilterOption {
+		return {
+			...option,
+			codecs: [...option.codecs]
+		};
+	}
+
+	function normalizeVideoQuality(value: string | undefined, fallback: VideoQuality): VideoQuality {
+		return value && VALID_VIDEO_QUALITIES.has(value as VideoQuality) ? (value as VideoQuality) : fallback;
+	}
+
+	function normalizeAudioQuality(value: string | undefined, fallback: AudioQuality): AudioQuality {
+		return value && VALID_AUDIO_QUALITIES.has(value as AudioQuality) ? (value as AudioQuality) : fallback;
+	}
+
+	function normalizeVideoCodecs(values: string[] | undefined): VideoCodec[] {
+		const codecs = values?.filter((codec): codec is VideoCodec =>
+			VALID_VIDEO_CODECS.has(codec as VideoCodec)
+		);
+		return codecs && codecs.length > 0 ? codecs : [...DEFAULT_FILTER_OPTION.codecs];
+	}
+
+	function filterOptionFromConfig(config: ConfigResponse): FilterOption {
+		return {
+			video_max_quality: normalizeVideoQuality(
+				config.video_max_quality,
+				DEFAULT_FILTER_OPTION.video_max_quality
+			),
+			video_min_quality: normalizeVideoQuality(
+				config.video_min_quality,
+				DEFAULT_FILTER_OPTION.video_min_quality
+			),
+			audio_max_quality: normalizeAudioQuality(
+				config.audio_max_quality,
+				DEFAULT_FILTER_OPTION.audio_max_quality
+			),
+			audio_min_quality: normalizeAudioQuality(
+				config.audio_min_quality,
+				DEFAULT_FILTER_OPTION.audio_min_quality
+			),
+			codecs: normalizeVideoCodecs(config.codecs),
+			no_dolby_video: config.no_dolby_video ?? DEFAULT_FILTER_OPTION.no_dolby_video,
+			no_dolby_audio: config.no_dolby_audio ?? DEFAULT_FILTER_OPTION.no_dolby_audio,
+			no_hdr: config.no_hdr ?? DEFAULT_FILTER_OPTION.no_hdr,
+			no_hires: config.no_hires ?? DEFAULT_FILTER_OPTION.no_hires
+		};
 	}
 
 	function updateSourceInStore(sourceType: string, sourceId: number, updater: SourceUpdater) {
@@ -643,6 +744,56 @@
 				}
 			}
 		);
+	}
+
+	async function handleOpenFilterOptionDialog(sourceType: string, source: VideoSource) {
+		filterOptionInfo = {
+			type: sourceType,
+			id: source.id,
+			name: source.name
+		};
+		filterOptionInheritGlobal = !source.filter_option;
+		filterOptionDraft = cloneFilterOption(source.filter_option ?? DEFAULT_FILTER_OPTION);
+		showFilterOptionDialog = true;
+
+		if (!source.filter_option) {
+			const response = await runRequest(() => api.getConfig(), {
+				context: '加载全局流过滤设置失败'
+			});
+			if (response) {
+				filterOptionDraft = filterOptionFromConfig(response.data);
+			}
+		}
+	}
+
+	async function handleSaveFilterOption() {
+		if (!filterOptionInheritGlobal && filterOptionDraft.codecs.length === 0) {
+			toast.error('保存失败', { description: '至少保留一个编解码器' });
+			return;
+		}
+
+		filterOptionSaving = true;
+		const result = await runRequest(
+			() =>
+				api.updateVideoSourceDownloadOptions(filterOptionInfo.type, filterOptionInfo.id, {
+					filter_option: filterOptionInheritGlobal ? null : cloneFilterOption(filterOptionDraft)
+				}),
+			{ context: '保存源级流过滤设置失败' }
+		);
+		filterOptionSaving = false;
+		if (!result) return;
+
+		if (!result.data.success) {
+			toast.error('保存失败', { description: result.data.message });
+			return;
+		}
+
+		updateSourceInStore(filterOptionInfo.type, filterOptionInfo.id, (source) => ({
+			...source,
+			filter_option: result.data.filter_option ?? null
+		}));
+		toast.success(filterOptionInheritGlobal ? '已恢复继承全局流过滤设置' : '已保存源级码率设置');
+		showFilterOptionDialog = false;
 	}
 
 	// 切换仅下载音频设置
@@ -1469,6 +1620,9 @@
 													{#if source.split_chapters_after_download}
 														<span class="text-emerald-600">分章下载</span>
 													{/if}
+													{#if source.filter_option}
+														<span class="text-cyan-600">自定义码率</span>
+													{/if}
 													{#if source.use_dynamic_api}
 														<span class="text-blue-600">动态API已启用</span>
 													{/if}
@@ -1619,6 +1773,21 @@
 														class="h-4 w-4 {source.scan_deleted_videos_once
 															? 'text-orange-600'
 															: 'text-gray-400'}"
+													/>
+												</Button>
+
+												<!-- 源级流过滤/码率设置 -->
+												<Button
+													size="sm"
+													variant="ghost"
+													onclick={() => handleOpenFilterOptionDialog(sourceConfig.type, source)}
+													title={source.filter_option
+														? '编辑源级码率/流过滤'
+														: '设置源级码率/流过滤'}
+													class="h-8 w-8 p-0"
+												>
+													<SlidersHorizontalIcon
+														class="h-4 w-4 {source.filter_option ? 'text-cyan-600' : 'text-gray-400'}"
 													/>
 												</Button>
 
@@ -1972,6 +2141,62 @@
 				onclick={saveSubmissionScanConfig}
 			>
 				{submissionScanConfigSaving ? '保存中…' : '保存'}
+			</Button>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- 源级流过滤/码率设置对话框 -->
+<AlertDialog.Root bind:open={showFilterOptionDialog}>
+	<AlertDialog.Content class="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+		<AlertDialog.Header>
+			<AlertDialog.Title title="单独设置该同步源使用的视频/音频质量筛选规则">
+				源级码率设置
+			</AlertDialog.Title>
+			<AlertDialog.Description>
+				为「{filterOptionInfo.name}」单独设置视频质量、音频质量和编码优先级；继承全局时会使用设置页的全局视频质量配置。
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+
+		<div class="mt-4 space-y-5">
+			<div class="flex items-center justify-between rounded-lg border p-3">
+				<div class="space-y-1">
+					<Label for="filter-option-inherit-global">继承全局流过滤设置</Label>
+					<p class="text-muted-foreground text-xs">
+						开启后清空该源的自定义配置；关闭后保存当前编辑器内容作为该源专用码率规则。
+					</p>
+				</div>
+				<Switch
+					id="filter-option-inherit-global"
+					disabled={filterOptionSaving}
+					bind:checked={filterOptionInheritGlobal}
+				/>
+			</div>
+
+			{#if filterOptionInheritGlobal}
+				<div class="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+					当前将继承全局配置。如需给该专集、UP、收藏夹或稍后再看任务单独限码率，请关闭上面的开关。
+				</div>
+			{:else}
+				<FilterOptionEditor
+					value={filterOptionDraft}
+					disabled={filterOptionSaving}
+					on:change={(event) => (filterOptionDraft = event.detail)}
+				/>
+			{/if}
+		</div>
+
+		<AlertDialog.Footer class="mt-4">
+			<Button
+				size="sm"
+				variant="outline"
+				disabled={filterOptionSaving}
+				onclick={() => (showFilterOptionDialog = false)}
+			>
+				取消
+			</Button>
+			<Button size="sm" disabled={filterOptionSaving} onclick={handleSaveFilterOption}>
+				{filterOptionSaving ? '保存中…' : '保存'}
 			</Button>
 		</AlertDialog.Footer>
 	</AlertDialog.Content>


### PR DESCRIPTION
## 变更内容
- 为 collection/favorite/submission/watch_later/bangumi 源表新增 `filter_option` 字段和迁移。
- 下载流程优先使用源级流过滤配置，未设置时继承全局配置。
- 视频源管理页支持编辑/恢复继承源级码率设置。
- 添加新视频源页和批量添加弹窗支持创建时设置源级码率/流过滤。

## 验证
- `cargo check -p bili_sync --color never --message-format short`
- `npm run check:node20`（0 errors，保留既有 Svelte warnings）
- `npm run build:node20`（通过，保留既有 Svelte warnings）
- `git diff --check`