### PR TITLE
支持完全自定义 Webhook 请求模板

### DIFF
--- a/crates/bili_sync/src/api/handler.rs
+++ b/crates/bili_sync/src/api/handler.rs
@@ -10238,6 +10238,7 @@ pub async fn get_config() -> Result<ApiResponse<crate::api::response::ConfigResp
             webhook_custom_headers: config.notification.webhook_custom_headers.clone(),
             webhook_format: config.notification.webhook_format.clone(),
             webhook_custom_body: config.notification.webhook_custom_body.clone(),
+            webhook_synology_chat_template: config.notification.webhook_synology_chat_template.clone(),
             enable_scan_notifications: config.notification.enable_scan_notifications,
             notification_min_videos: config.notification.notification_min_videos,
             notification_timeout: config.notification.notification_timeout,
@@ -19198,6 +19199,17 @@ pub async fn test_notification_handler(
             config.webhook_custom_body = Some(v.to_string());
         }
     }
+    if let Some(webhook_synology_chat_template) = request.webhook_synology_chat_template.as_ref() {
+        if webhook_synology_chat_template.trim().is_empty() {
+            config.webhook_synology_chat_template = None;
+        } else {
+            crate::utils::notification::NotificationClient::validate_synology_chat_template(
+                webhook_synology_chat_template,
+            )
+            .map_err(ApiError::from)?;
+            config.webhook_synology_chat_template = Some(webhook_synology_chat_template.to_string());
+        }
+    }
 
     // 测试推送允许在未启用通知开关时执行，但仍需要可用渠道配置
     config.enable_scan_notifications = true;
@@ -19319,6 +19331,7 @@ pub async fn get_notification_config() -> Result<ApiResponse<crate::api::respons
         webhook_custom_headers: config.webhook_custom_headers,
         webhook_format: config.webhook_format,
         webhook_custom_body: config.webhook_custom_body,
+        webhook_synology_chat_template: config.webhook_synology_chat_template,
         enable_scan_notifications: config.enable_scan_notifications,
         notification_min_videos: config.notification_min_videos,
         notification_timeout: config.notification_timeout,
@@ -19464,6 +19477,20 @@ pub async fn update_notification_config(
             )
             .map_err(ApiError::from)?;
             notification_config.webhook_custom_body = Some(webhook_custom_body.trim().to_string());
+        }
+        updated = true;
+    }
+
+    if let Some(ref webhook_synology_chat_template) = request.webhook_synology_chat_template {
+        if webhook_synology_chat_template.trim().is_empty() {
+            notification_config.webhook_synology_chat_template = None;
+        } else {
+            crate::utils::notification::NotificationClient::validate_synology_chat_template(
+                webhook_synology_chat_template,
+            )
+            .map_err(ApiError::from)?;
+            notification_config.webhook_synology_chat_template =
+                Some(webhook_synology_chat_template.to_string());
         }
         updated = true;
     }

--- a/crates/bili_sync/src/api/request.rs
+++ b/crates/bili_sync/src/api/request.rs
@@ -416,6 +416,7 @@ pub struct UpdateNotificationConfigRequest {
     pub webhook_custom_headers: Option<String>,
     pub webhook_format: Option<String>,
     pub webhook_custom_body: Option<String>,
+    pub webhook_synology_chat_template: Option<String>,
     pub enable_scan_notifications: Option<bool>,
     pub notification_min_videos: Option<usize>,
     pub notification_timeout: Option<u64>,
@@ -440,6 +441,7 @@ pub struct TestNotificationRequest {
     pub webhook_custom_headers: Option<String>,
     pub webhook_format: Option<String>,
     pub webhook_custom_body: Option<String>,
+    pub webhook_synology_chat_template: Option<String>,
 }
 
 // 分页状态更新结构

--- a/crates/bili_sync/src/api/response.rs
+++ b/crates/bili_sync/src/api/response.rs
@@ -1051,6 +1051,7 @@ pub struct NotificationConfigResponse {
     pub webhook_custom_headers: Option<String>,
     pub webhook_format: String,
     pub webhook_custom_body: Option<String>,
+    pub webhook_synology_chat_template: Option<String>,
     pub enable_scan_notifications: bool,
     pub notification_min_videos: usize,
     pub notification_timeout: u64,

--- a/crates/bili_sync/src/config/mod.rs
+++ b/crates/bili_sync/src/config/mod.rs
@@ -324,6 +324,9 @@ pub struct NotificationConfig {
     pub webhook_format: String, // "auto", "generic", "opensend", "custom", "synology_chat"
     #[serde(default)]
     pub webhook_custom_body: Option<String>,
+    /// 仅用于 Synology Chat：消息文本模板，不是 JSON。
+    #[serde(default)]
+    pub webhook_synology_chat_template: Option<String>,
 
     // === 通用配置 ===
     #[serde(default)]
@@ -376,6 +379,7 @@ impl Default for NotificationConfig {
             webhook_custom_headers: None,
             webhook_format: default_webhook_format(),
             webhook_custom_body: None,
+            webhook_synology_chat_template: None,
             enable_scan_notifications: false,
             notification_min_videos: default_notification_min_videos(),
             notification_timeout: default_notification_timeout(),
@@ -502,7 +506,7 @@ impl NotificationConfig {
                     if self.webhook_format == "custom"
                         && self.webhook_custom_body.as_ref().is_none_or(|v| v.trim().is_empty())
                     {
-                        return Err("已选择自定义 JSON 但未配置 POST Body".to_string());
+                        return Err("已选择自定义请求 但未配置 POST Body".to_string());
                     }
                     if let Some(custom_headers) = self
                         .webhook_custom_headers

--- a/crates/bili_sync/src/utils/notification.rs
+++ b/crates/bili_sync/src/utils/notification.rs
@@ -90,6 +90,8 @@ struct GenericWebhookRequest {
     sent_at: String,
 }
 
+const DEFAULT_SYNOLOGY_CHAT_TEMPLATE: &str = ":loudspeaker: ------{{title}}------ :loudspeaker:\n{{content}}";
+
 // 推送通知客户端
 pub struct NotificationClient {
     client: Client,
@@ -428,14 +430,14 @@ impl NotificationClient {
                 .filter(|v| !v.trim().is_empty())
                 .ok_or_else(|| anyhow!("未配置自定义 POST Body"))?;
             let rendered = Self::render_custom_webhook_body(custom_body, &payload)?;
-            req.json(&rendered).send().await?
+            req.body(rendered).send().await?
         } else if is_synology_chat {
             // Synology Chat 的 Incoming Webhook 不是 JSON API：它要求
             // application/x-www-form-urlencoded，且 JSON 必须作为 payload 字段的值。
             // 这里先序列化内层对象，再让 reqwest 对整个表单字段做一次 URL 编码，
             // 不能把 JSON 字符串再包进一个 JSON 对象，否则群晖会静默丢弃消息。
             let synology_payload = serde_json::to_string(&serde_json::json!({
-                "text": format!("{}\n\n{}", title, content),
+                "text": self.render_synology_chat_text(&payload),
                 "username": "bili-sync"
             }))?;
             req.form(&[("payload", synology_payload)]).send().await?
@@ -492,7 +494,7 @@ impl NotificationClient {
                 .is_none_or(|value| value.trim().is_empty())
         {
             debug!(
-                "Webhook渠道使用自定义 JSON 但未配置 POST Body，跳过{}",
+                "Webhook渠道使用自定义请求 但未配置 POST Body，跳过{}",
                 notification_name
             );
             return None;
@@ -695,14 +697,115 @@ impl NotificationClient {
         map
     }
 
-    fn render_custom_webhook_body(template: &str, payload: &GenericWebhookRequest) -> Result<serde_json::Value> {
-        let parsed: serde_json::Value =
-            serde_json::from_str(template).map_err(|e| anyhow!("自定义 POST Body 不是有效 JSON: {}", e))?;
+    fn render_custom_webhook_body(template: &str, payload: &GenericWebhookRequest) -> Result<String> {
         let context = Self::build_custom_webhook_context(payload);
-        Ok(Self::apply_template_placeholders(parsed, &context))
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(template) {
+            let rendered = Self::apply_template_placeholders(parsed, &context);
+            return serde_json::to_string(&rendered).map_err(Into::into);
+        }
+
+        Ok(Self::apply_raw_webhook_template(template, &context))
+    }
+
+    fn apply_raw_webhook_template(template: &str, context: &serde_json::Map<String, serde_json::Value>) -> String {
+        let mut rendered = template.to_string();
+        for (key, value) in context {
+            let text = Self::placeholder_scalar_text(value);
+            let json_placeholder = format!("{{{{{}_json}}}}", key);
+            let form_placeholder = format!("{{{{{}_urlencoded}}}}", key);
+            let placeholder = format!("{{{{{}}}}}", key);
+            let json_text = serde_json::to_string(&text).unwrap_or_default();
+            rendered = rendered.replace(&json_placeholder, &json_text);
+            rendered = rendered.replace(&form_placeholder, &Self::form_urlencode(&text));
+            rendered = rendered.replace(&placeholder, &text);
+        }
+        rendered
+    }
+
+    fn form_urlencode(value: &str) -> String {
+        let mut encoded = String::with_capacity(value.len());
+        for byte in value.bytes() {
+            match byte {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'*' => encoded.push(byte as char),
+                b' ' => encoded.push('+'),
+                _ => {
+                    use std::fmt::Write;
+                    let _ = write!(encoded, "%{byte:02X}");
+                }
+            }
+        }
+        encoded
+    }
+
+    fn render_synology_chat_text(&self, payload: &GenericWebhookRequest) -> String {
+        let template = self
+            .config
+            .webhook_synology_chat_template
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(DEFAULT_SYNOLOGY_CHAT_TEMPLATE);
+        let mut context = Self::build_custom_webhook_context(payload);
+        context.insert(
+            "content".to_string(),
+            serde_json::Value::String(Self::plain_text_for_synology_chat(&payload.content)),
+        );
+
+        let mut rendered = template.to_string();
+        for (key, value) in context {
+            let placeholder = format!("{{{{{}}}}}", key);
+            rendered = rendered.replace(&placeholder, &Self::placeholder_scalar_text(&value));
+        }
+        rendered
+    }
+
+    fn plain_text_for_synology_chat(content: &str) -> String {
+        content
+            .lines()
+            .map(|line| {
+                let trimmed = line.trim_start();
+                let plain = if let Some(item) = trimmed.strip_prefix("- ") {
+                    format!("• {}", item)
+                } else {
+                    let heading = trimmed.trim_start_matches('#');
+                    if heading.len() != trimmed.len() && heading.chars().next().is_some_and(char::is_whitespace) {
+                        heading.trim_start().to_string()
+                    } else {
+                        line.to_string()
+                    }
+                };
+                plain.replace("**", "").replace('`', "")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    pub fn validate_synology_chat_template(template: &str) -> Result<()> {
+        if template.trim().is_empty() {
+            return Err(anyhow!("Synology Chat 消息模板不能为空"));
+        }
+
+        let sample_payload = GenericWebhookRequest {
+            source: "bili-sync".to_string(),
+            title: "Bili Sync 测试推送".to_string(),
+            content: "这是一条Webhook测试推送消息。".to_string(),
+            channel: "webhook".to_string(),
+            event: "test_notification".to_string(),
+            sent_at: chrono::Local::now().to_rfc3339(),
+        };
+        let mut config = NotificationConfig::default();
+        config.webhook_synology_chat_template = Some(template.to_string());
+        let client = Self::new(config);
+        let rendered = client.render_synology_chat_text(&sample_payload);
+        if rendered.trim().is_empty() {
+            return Err(anyhow!("Synology Chat 消息模板渲染后不能为空"));
+        }
+        Ok(())
     }
 
     pub fn validate_custom_webhook_body_template(template: &str) -> Result<()> {
+        if template.trim().is_empty() {
+            return Err(anyhow!("自定义 POST Body 不能为空"));
+        }
         let sample_payload = GenericWebhookRequest {
             source: "bili-sync".to_string(),
             title: "Bili Sync 测试推送".to_string(),
@@ -949,7 +1052,7 @@ impl NotificationClient {
                         .as_ref()
                         .is_none_or(|value| value.trim().is_empty())
                 {
-                    return Err(anyhow!("Webhook渠道已选择自定义 JSON 但未配置 POST Body"));
+                    return Err(anyhow!("Webhook渠道已选择自定义请求 但未配置 POST Body"));
                 }
 
                 let title = "Bili Sync 测试推送";
@@ -1011,7 +1114,7 @@ impl NotificationClient {
                         .as_ref()
                         .is_none_or(|value| value.trim().is_empty())
                 {
-                    return Err(anyhow!("Webhook渠道已选择自定义 JSON 但未配置 POST Body"));
+                    return Err(anyhow!("Webhook渠道已选择自定义请求 但未配置 POST Body"));
                 }
                 self.send_to_webhook(webhook_url, title, &content, "custom_test_notification")
                     .await?;
@@ -1439,6 +1542,48 @@ mod tests {
         assert!(NotificationClient::validate_custom_webhook_headers(r#"{"Bad Header":"value"}"#).is_err());
     }
 
+    #[test]
+    fn test_custom_webhook_body_allows_raw_templates() {
+        let payload = GenericWebhookRequest {
+            source: "bili-sync".to_string(),
+            title: "测试标题".to_string(),
+            content: "测试正文".to_string(),
+            channel: "webhook".to_string(),
+            event: "test_notification".to_string(),
+            sent_at: "2026-07-28T00:00:00+08:00".to_string(),
+        };
+
+        assert!(
+            NotificationClient::validate_custom_webhook_body_template("payload={{title}}&message={{content}}").is_ok()
+        );
+        assert_eq!(
+            NotificationClient::render_custom_webhook_body(
+                "payload={{title_urlencoded}}&message={{content_urlencoded}}&json={{content_json}}",
+                &payload,
+            )
+            .expect("raw template should render"),
+            "payload=%E6%B5%8B%E8%AF%95%E6%A0%87%E9%A2%98&message=%E6%B5%8B%E8%AF%95%E6%AD%A3%E6%96%87&json=\"测试正文\""
+        );
+    }
+
+    #[test]
+    fn test_synology_chat_default_template_uses_plain_text() {
+        let client = NotificationClient::new(NotificationConfig::default());
+        let payload = GenericWebhookRequest {
+            source: "bili-sync".to_string(),
+            title: "扫描完成".to_string(),
+            content: "📊 **扫描摘要**\n- 新增视频: 1个".to_string(),
+            channel: "webhook".to_string(),
+            event: "scan_completion".to_string(),
+            sent_at: "2026-07-28T00:00:00+08:00".to_string(),
+        };
+
+        assert_eq!(
+            client.render_synology_chat_text(&payload),
+            ":loudspeaker: ------扫描完成------ :loudspeaker:\n📊 扫描摘要\n• 新增视频: 1个"
+        );
+    }
+
     #[derive(Debug, Clone)]
     struct CapturedWebhookRequest {
         authorization: Option<String>,
@@ -1616,13 +1761,15 @@ mod tests {
         config.webhook_url = Some(url);
         config.webhook_format = "synology_chat".to_string();
         config.webhook_custom_headers = Some(r#"{"Content-Type":"application/json"}"#.to_string());
+        config.webhook_synology_chat_template =
+            Some(":loudspeaker: {{title}}\n:mailbox_closed: {{content}}\n{{event}}".to_string());
 
         let client = NotificationClient::new(config);
         client
             .send_to_webhook(
                 client.config.webhook_url.as_deref().unwrap(),
                 "群晖标题",
-                "群晖正文",
+                "**群晖正文**\n- 第二项",
                 "test_notification",
             )
             .await
@@ -1647,7 +1794,7 @@ mod tests {
         );
         assert_eq!(
             payload.get("text").and_then(|value| value.as_str()),
-            Some("群晖标题\n\n群晖正文")
+            Some(":loudspeaker: 群晖标题\n:mailbox_closed: 群晖正文\n• 第二项\ntest_notification")
         );
     }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -966,6 +966,7 @@ class ApiClient {
 			webhook_custom_headers?: string;
 			webhook_format?: string;
 			webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 			notification_min_videos: number;
 			notification_timeout: number;
 			notification_retry_count: number;
@@ -986,6 +987,7 @@ class ApiClient {
 			webhook_custom_headers?: string;
 			webhook_format?: string;
 			webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 			notification_min_videos: number;
 			notification_timeout: number;
 			notification_retry_count: number;
@@ -1010,6 +1012,7 @@ class ApiClient {
 		webhook_custom_headers?: string;
 		webhook_format?: string;
 		webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 		notification_min_videos?: number;
 	}): Promise<ApiResponse<string>> {
 		return this.post<string>('/config/notification', config);
@@ -1033,6 +1036,7 @@ class ApiClient {
 		webhook_custom_headers?: string;
 		webhook_format?: string;
 		webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 	}): Promise<
 		ApiResponse<{
 			success: boolean;
@@ -1446,6 +1450,7 @@ export const api = {
 		webhook_custom_headers?: string;
 		webhook_format?: string;
 		webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 		notification_min_videos?: number;
 	}) => apiClient.updateNotificationConfig(config),
 
@@ -1467,6 +1472,7 @@ export const api = {
 		webhook_custom_headers?: string;
 		webhook_format?: string;
 		webhook_custom_body?: string;
+			webhook_synology_chat_template?: string;
 	}) => apiClient.testNotification(params),
 
 	/**

--- a/web/src/routes/settings/+page.svelte
+++ b/web/src/routes/settings/+page.svelte
@@ -376,6 +376,7 @@
 	let webhookCustomHeaders = '';
 	let webhookFormat: 'auto' | 'generic' | 'opensend' | 'custom' | 'synology_chat' = 'auto';
 	let webhookCustomBody = '';
+	let webhookSynologyChatTemplate = '';
 	let notificationMinVideos = 1;
 	let notificationSaving = false;
 	let notificationStatus: {
@@ -408,6 +409,9 @@
   "event": "{{event}}",
   "sent_at": "{{sent_at}}"
 }`;
+	const defaultWebhookFormBody = `message={{content_urlencoded}}`;
+	const defaultSynologyChatTemplate = `:loudspeaker: ------{{title}}------ :loudspeaker:
+{{content}}`;
 
 	// 显示帮助信息的状态（在文件命名抽屉中使用）
 	let showHelp = false;
@@ -1395,6 +1399,7 @@
 			config.webhook_custom_headers = webhookCustomHeaders.trim();
 			config.webhook_format = webhookFormat;
 			config.webhook_custom_body = webhookCustomBody.trim();
+			config.webhook_synology_chat_template = webhookSynologyChatTemplate;
 		}
 
 		const response = await runRequest(() => api.updateNotificationConfig(config), {
@@ -1548,6 +1553,9 @@
 				| undefined) ||
 			'auto';
 		webhookCustomBody = response.data.webhook_custom_body || '';
+		webhookSynologyChatTemplate =
+			response.data.webhook_synology_chat_template ||
+			(webhookFormat === 'synology_chat' ? defaultSynologyChatTemplate : '');
 	}
 
 	// 测试推送通知
@@ -1576,6 +1584,7 @@
 			request.webhook_custom_headers = webhookCustomHeaders.trim();
 			request.webhook_format = webhookFormat;
 			request.webhook_custom_body = webhookCustomBody.trim();
+			request.webhook_synology_chat_template = webhookSynologyChatTemplate;
 		}
 
 		const response = await runRequest(() => api.testNotification(request), {
@@ -4103,7 +4112,7 @@
 								{ value: 'auto', label: '自动识别（推荐）' },
 								{ value: 'generic', label: '通用 JSON' },
 								{ value: 'opensend', label: 'openSend' },
-								{ value: 'custom', label: '自定义 JSON' },
+								{ value: 'custom', label: '自定义请求' },
 								{ value: 'synology_chat', label: 'Synology Chat（群晖）' }
 							]}
 							onChange={(nextValue) =>
@@ -4111,8 +4120,8 @@
 							class="bg-background border-input ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
 						/>
 						<p class="text-muted-foreground text-sm">
-							自动识别会根据URL判断；openSend 会发送其专用字段并附带 apikey 头；自定义 JSON
-							可自行定义 POST Body 结构；Synology Chat 会按群晖要求发送 <code>payload=</code>
+							自动识别、openSend 与 Synology Chat 均为预设模板；自定义请求可发送任意 POST Body，
+							不限制消息类型。Synology Chat 会按群晖要求发送 <code>payload=</code>
 							表单。
 						</p>
 					</div>
@@ -4169,17 +4178,30 @@
 					{#if webhookFormat === 'custom'}
 						<div class="space-y-2">
 							<div class="flex items-center justify-between gap-3">
-								<Label for="generic-webhook-custom-body">自定义 POST Body</Label>
-								<Button
-									type="button"
-									variant="outline"
-									size="sm"
-									onclick={() => {
-										webhookCustomBody = defaultWebhookCustomBody;
-									}}
-								>
-									填入示例
-								</Button>
+								<Label for="generic-webhook-custom-body">自定义 POST Body（任意文本）</Label>
+								<div class="flex gap-2">
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onclick={() => {
+											webhookCustomBody = defaultWebhookCustomBody;
+										}}
+									>
+										JSON 模板
+									</Button>
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onclick={() => {
+											webhookCustomBody = defaultWebhookFormBody;
+											webhookCustomHeaders = '{"Content-Type":"application/x-www-form-urlencoded"}';
+										}}
+									>
+										表单模板
+									</Button>
+								</div>
 							</div>
 							<Textarea
 								id="generic-webhook-custom-body"
@@ -4198,10 +4220,38 @@
 								<p>&#123;&#123;channel&#125;&#125;：当前通知渠道名称，例如 webhook</p>
 								<p>&#123;&#123;event&#125;&#125;：事件类型，例如 test_notification</p>
 								<p>&#123;&#123;sent_at&#125;&#125;：发送时间</p>
-								<p>
-									请直接填写有效
-									JSON。若某个值只写占位符，发送时会按原始类型写入；若嵌在字符串中，则会按文本替换。
-								</p>
+								<p>可填写 JSON、<code>application/x-www-form-urlencoded</code> 或任意原始文本；不会限制消息类型。</p>
+								<p>JSON 模板继续兼容原有安全替换；其他格式按原文本替换占位符。原始模板还支持 <code>&#123;&#123;title_json&#125;&#125;</code> 和 <code>&#123;&#123;title_urlencoded&#125;&#125;</code>（其他字段同理）。</p>
+							</div>
+						</div>
+					{/if}
+
+					{#if webhookFormat === 'synology_chat'}
+						<div class="space-y-2">
+							<div class="flex items-center justify-between gap-3">
+								<Label for="synology-chat-template">群晖 Chat 消息模板</Label>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onclick={() => {
+										webhookSynologyChatTemplate = defaultSynologyChatTemplate;
+									}}
+								>
+									填入模板
+								</Button>
+							</div>
+							<Textarea
+								id="synology-chat-template"
+								bind:value={webhookSynologyChatTemplate}
+								rows={8}
+								placeholder={defaultSynologyChatTemplate}
+								class="font-mono text-xs"
+							/>
+							<div class="text-muted-foreground space-y-1 text-sm">
+								<p>这是纯文本模板，不会按 Markdown 解析；可直接使用群晖表情短码，例如 <code>:loudspeaker:</code>、<code>:mailbox_closed:</code>。</p>
+								<p>支持占位符：&#123;&#123;title&#125;&#125;、&#123;&#123;content&#125;&#125;、&#123;&#123;source&#125;&#125;、&#123;&#123;channel&#125;&#125;、&#123;&#123;event&#125;&#125;、&#123;&#123;sent_at&#125;&#125;；&#123;&#123;content&#125;&#125; 会自动移除 Markdown 标记。</p>
+								<p>留空时使用默认模板：<code>:loudspeaker: ------&#123;&#123;title&#125;&#125;------ :loudspeaker:</code> 后换行显示正文。</p>
 							</div>
 						</div>
 					{/if}


### PR DESCRIPTION
## 功能
- 将自定义 Webhook 从仅 JSON 扩展为任意原始 POST Body。
- 提供 JSON、表单和 Synology Chat 预设模板。
- 支持原文本、JSON 转义及 URL 编码占位符。
- Synology Chat 消息模板改为纯文本并自动清理 Markdown 标记。

## 验证
- cargo test -p bili_sync --bin bili-sync-rs utils::notification::tests -- --nocapture
- npm run check:node20